### PR TITLE
Specify `latest` versions of buildpacks

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -6,86 +6,94 @@ run-image = "heroku/pack:18"
 [[buildpacks]]
   id = "heroku/java"
   uri = "https://github.com/heroku/java-buildpack/releases/download/v0.13/java-buildpack-v0.13.tgz"
+  latest = true
 
 [[buildpacks]]
   id = "heroku/ruby"
   uri = "https://github.com/heroku/heroku-buildpack-ruby/releases/download/cnb-alpha/ruby-buildpack-vCNB-alpha.tgz"
+  latest = true
 
 [[buildpacks]]
   id = "heroku/procfile"
   uri = "https://github.com/heroku/procfile-cnb/releases/download/v0.2/procfile-cnb-v0.2.tgz"
+  latest = true
 
 [[buildpacks]]
   id = "heroku/python"
   uri = "buildpacks/python"
+  latest = true
 
 [[buildpacks]]
   id = "heroku/gradle"
   uri = "buildpacks/gradle"
+  latest = true
 
 [[buildpacks]]
   id = "heroku/php"
   uri = "buildpacks/php"
+  latest = true
 
 [[buildpacks]]
   id = "heroku/go"
   uri = "buildpacks/go"
+  latest = true
 
 [[buildpacks]]
   id = "heroku/nodejs"
   uri = "buildpacks/nodejs"
+  latest = true
 
 [[groups]]
   [[groups.buildpacks]]
     id = "heroku/ruby"
-    version = "0.0.1"
+    version = "latest"
 
   [[groups.buildpacks]]
     id = "heroku/procfile"
-    version = "0.2"
+    version = "latest"
     optional = true
 
 [[groups]]
   [[groups.buildpacks]]
     id = "heroku/python"
-    version = "v0.0.4.0.1"
+    version = "latest"
 
   [[groups.buildpacks]]
     id = "heroku/procfile"
-    version = "0.2"
+    version = "latest"
     optional = true
 
 [[groups]]
   [[groups.buildpacks]]
     id = "heroku/java"
-    version = "0.13"
+    version = "latest"
 
 [[groups]]
   [[groups.buildpacks]]
     id = "heroku/gradle"
-    version = "v0.0.4.0.1"
+    version = "latest"
 
 [[groups]]
   [[groups.buildpacks]]
     id = "heroku/php"
-    version = "v0.0.4.0.1"
+    version = "latest"
 
   [[groups.buildpacks]]
     id = "heroku/procfile"
-    version = "0.2"
+    version = "latest"
     optional = true
 
 [[groups]]
   [[groups.buildpacks]]
     id = "heroku/go"
-    version = "v0.0.4.0.1"
+    version = "latest"
 
   [[groups.buildpacks]]
     id = "heroku/procfile"
-    version = "0.2"
+    version = "latest"
     optional = true
 
 [[groups]]
   [[groups.buildpacks]]
     id = "heroku/nodejs"
-    version = "v0.0.4.0.1"
+    version = "latest"


### PR DESCRIPTION
This flag tells `create-builder` to create symlinks from buildpacks/heroku_go/latest to buildpacks/heroku_go/vX.X.X. This makes it easier to specify a buildpack during build without having to know internal version numbers. Previous to this change `pack build foo --builder heroku/buildpacks:18 --buildpack heroku/go` would fail with `there is no version of buildpack heroku/go marked as latest`, so users would need to specify a version like `pack build foo --builder heroku/buildpacks:18 --buildpack heroku/go@v0.0.4.0.1`.

More on this flag is in the [pack docs](https://github.com/buildpack/pack#builder-configuration)