### PR TITLE
CircleCI Refactor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,6 @@ jobs:
       - run: docker load < docker_cache_run_base/pack-18.tar
       - run: docker load < docker_cache_builder/buildpacks-18.tar
       - run: pack build pack-getting-started --path getting_started --builder heroku/buildpacks:18 --no-pull
-
 workflows:
   version: 2
   test-languages:
@@ -125,7 +124,7 @@ workflows:
           requires:
             - create-builder-image
       - test-getting-started-guide:
-          language: nodejs
+          language: node-js
           name: Test Node.js
           requires:
             - create-builder-image


### PR DESCRIPTION
This PR does two things:
* Upgrade to CircleCI 2.1 so we can use [parameterized jobs](https://circleci.com/docs/2.0/reusing-config/#authoring-parameterized-jobs)
* Refactor all the "test-X" jobs into one job with a parameter for the language so we can clone the correct repo.

@jkutner approved #8 before I could review while on PTO :P