### PR TITLE
Bump node-function-buildpack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,6 @@ publish: build
 build-ci:
 	@docker build -f Dockerfile.ci -t heroku/pack-runner:latest .
 	@docker push heroku/pack-runner:latest
+
+create-builder-fn-local:
+	@pack create-builder pack-images-local --builder-config functions-builder.toml --no-pull

--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -10,11 +10,11 @@ run-image = "heroku/pack:18"
 
 [[buildpacks]]
   id = "heroku/node-function"
-  uri = "https://github.com/heroku/node-function-buildpack/releases/download/v0.4.0/node-function-buildpack-v0.4.0.tgz"
+  uri = "https://github.com/heroku/node-function-buildpack/releases/download/v0.4.1/node-function-buildpack-v0.4.1.tgz"
 
 [[groups]]
   # node functions
   buildpacks = [
     { id = "heroku/nodejs", version = "latest" },
-    { id = "heroku/node-function", version = "0.4.0" },
+    { id = "heroku/node-function", version = "0.4.1" },
   ]


### PR DESCRIPTION
This will enable future builds to support cloudevents v0.3