### PR TITLE
Update to latest node function buildpack

### DIFF
--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -10,11 +10,11 @@ run-image = "heroku/pack:18"
 
 [[buildpacks]]
   id = "heroku/node-function"
-  uri = "https://github.com/heroku/node-function-buildpack/releases/download/v0.4.1/node-function-buildpack-v0.4.1.tgz"
+  uri = "https://github.com/heroku/node-function-buildpack/releases/download/v0.4.2/node-function-buildpack-v0.4.2.tgz"
 
 [[groups]]
   # node functions
   buildpacks = [
     { id = "heroku/nodejs", version = "latest" },
-    { id = "heroku/node-function", version = "0.4.1" },
+    { id = "heroku/node-function", version = "0.4.2" },
   ]


### PR DESCRIPTION
This updates the function builder images to use v0.4.2 of heroku/node-function-buildpack, which introduces the system function.