### PR TITLE
Revert "Bump heroku/nodejs-function to 0.6.6"

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -46,7 +46,7 @@ version = "0.11.4"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:438e6ed49549a7cdf686f6add784d851a211183b6c73c8f1d2e3d1ca586188e2"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:9d033f6c8ccc152043d427bd49cbed030a2e8dbab890d529e03c4b17a15b70f8"
 
 [[order]]
   [[order.group]]
@@ -101,7 +101,7 @@ version = "0.11.4"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.6.7"
+    version = "0.6.5"
 
 [[order]]
   [[order.group]]

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -46,7 +46,7 @@ version = "0.11.4"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:438e6ed49549a7cdf686f6add784d851a211183b6c73c8f1d2e3d1ca586188e2"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:9d033f6c8ccc152043d427bd49cbed030a2e8dbab890d529e03c4b17a15b70f8"
 
 [[order]]
   [[order.group]]
@@ -101,7 +101,7 @@ version = "0.11.4"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.6.7"
+    version = "0.6.5"
 
 [[order]]
   [[order.group]]


### PR DESCRIPTION
Reverts heroku/pack-images#207.

This change caused the Function Canary to fail. JavaScript and Typescript functions got stuck in `"status": "starting"`.