### PR TITLE
Update Ruby to 0.1.3

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -22,7 +22,7 @@ version = "0.11.4"
 
 [[buildpacks]]
   id = "heroku/ruby"
-  uri = "https://github.com/heroku/heroku-buildpack-ruby/releases/download/v222/heroku-buildpack-ruby-v222.tgz"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-ruby-buildpack@sha256:3eeb3773cdbd29d4fb0d578f7781fe8c525de73593480e2740b7143262e5bef5"
 
 [[buildpacks]]
   id = "heroku/procfile"
@@ -51,7 +51,7 @@ version = "0.11.4"
 [[order]]
   [[order.group]]
     id = "heroku/ruby"
-    version = "0.0.1"
+    version = "0.1.3"
 
   [[order.group]]
     id = "heroku/procfile"

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -22,7 +22,7 @@ version = "0.11.4"
 
 [[buildpacks]]
   id = "heroku/ruby"
-  uri = "https://github.com/heroku/heroku-buildpack-ruby/releases/download/v222/heroku-buildpack-ruby-v222.tgz"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-ruby-buildpack@sha256:3eeb3773cdbd29d4fb0d578f7781fe8c525de73593480e2740b7143262e5bef5"
 
 [[buildpacks]]
   id = "heroku/procfile"
@@ -51,7 +51,7 @@ version = "0.11.4"
 [[order]]
   [[order.group]]
     id = "heroku/ruby"
-    version = "0.0.1"
+    version = "0.1.3"
 
   [[order.group]]
     id = "heroku/procfile"


### PR DESCRIPTION


```
$ pack build issuetriage -b public.ecr.aws/heroku-buildpacks/heroku-ruby-buildpack@sha256:3eeb3773cdbd29d4fb0d578f7781fe8c525de73593480e2740b7143262e5bef5 -p .
18: Pulling from heroku/buildpacks
284055322776: Already exists
d5cfd425797b: Already exists
96dcda2dad4f: Already exists
557d4e018c83: Already exists
28b8487d480f: Already exists
6427e11e4b72: Pull complete
405cd9c87271: Pull complete
357fefdf9bc9: Pull complete
6fa475a1dd3f: Pull complete
1f05f35ceef1: Pull complete
03fb7dba7baa: Pull complete
c3e1c128760e: Pull complete
8f7ab136a2c9: Pull complete
d2a2659301d3: Pull complete
5035dafe4b03: Pull complete
80729d88ae8d: Pull complete
6018af265953: Pull complete
4bfdb67d04f5: Pull complete
0494ca24cd11: Pull complete
ae945079ae39: Pull complete
491c1ce9c4f9: Pull complete
be13a8b639fa: Pull complete
7a0d451ed1cd: Pull complete
f18d74887f79: Pull complete
c10fd1b9aa75: Pull complete
6a19c4a9cc6d: Pull complete
e39f36c309b9: Pull complete
2868599e67e5: Pull complete
08d54b036422: Pull complete
17d8a8efaf58: Pull complete
e80fe5117c2a: Pull complete
4f4fb700ef54: Pull complete
Digest: sha256:ff2d9689d0a1407797e6a7e910443d67fe7f2f4a27428dde781c1dec9f3f4a55
Status: Downloaded newer image for heroku/buildpacks:18
18: Pulling from heroku/pack
284055322776: Already exists
d5cfd425797b: Already exists
96dcda2dad4f: Already exists
92696cad13fd: Pull complete
439f2c753d37: Pull complete
Digest: sha256:f8782da1e2b58c9eb50e4b25a5f8e096eae393ee8e393adc7bb862578c3ec201
Status: Downloaded newer image for heroku/pack:18
public.ecr.aws/heroku-buildpacks/heroku-ruby-buildpack@sha256:3eeb3773cdbd29d4fb0d578f7781fe8c525de73593480e2740b7143262e5bef5: Pulling from heroku-buildpacks/heroku-ruby-buildpack
eceeede51d22: Pull complete
Digest: sha256:3eeb3773cdbd29d4fb0d578f7781fe8c525de73593480e2740b7143262e5bef5
Status: Downloaded newer image for public.ecr.aws/heroku-buildpacks/heroku-ruby-buildpack@sha256:3eeb3773cdbd29d4fb0d578f7781fe8c525de73593480e2740b7143262e5bef5
===> DETECTING
heroku/ruby 0.1.3
===> ANALYZING
Previous image with name "issuetriage" not found
===> RESTORING
===> BUILDING
-----> Installing bundler 2.2.21
-----> Removing BUNDLED WITH version in the Gemfile.lock
-----> Compiling Ruby/Rails
```