### PR TITLE
Update JVM buildpacks

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -10,7 +10,7 @@ version = "0.11.4"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:2dc6e31e669a3fe762dd130aad7c4dc4e6596ef11c55329b1a61f62d7e2512a5"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:e1a7081e1ffa53870229c331a9d700ae640e2a47d36085d6b2260f913dd1e7e9"
 
 [[buildpacks]]
   id = "heroku/scala"
@@ -18,7 +18,7 @@ version = "0.11.4"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:2d04357459e5e24bf5af5fc56432637abd4f6f6e7dc17bb6c6665a33685a0eb1"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:f506598a47ee80c1eba98345fb49be66745dcb3e6d01a9f1b98a93e095c84ddd"
 
 [[buildpacks]]
   id = "heroku/ruby"
@@ -106,7 +106,7 @@ version = "0.11.4"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.23"
+    version = "0.3.24"
 
 [[order]]
   [[order.group]]
@@ -116,4 +116,4 @@ version = "0.11.4"
 [[order]]
   [[order.group]]
     id = "heroku/java"
-    version = "0.3.12"
+    version = "0.3.13"

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -10,7 +10,7 @@ version = "0.11.4"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:2dc6e31e669a3fe762dd130aad7c4dc4e6596ef11c55329b1a61f62d7e2512a5"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:e1a7081e1ffa53870229c331a9d700ae640e2a47d36085d6b2260f913dd1e7e9"
 
 [[buildpacks]]
   id = "heroku/scala"
@@ -18,7 +18,7 @@ version = "0.11.4"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:2d04357459e5e24bf5af5fc56432637abd4f6f6e7dc17bb6c6665a33685a0eb1"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:f506598a47ee80c1eba98345fb49be66745dcb3e6d01a9f1b98a93e095c84ddd"
 
 [[buildpacks]]
   id = "heroku/ruby"
@@ -106,7 +106,7 @@ version = "0.11.4"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.23"
+    version = "0.3.24"
 
 [[order]]
   [[order.group]]
@@ -116,4 +116,4 @@ version = "0.11.4"
 [[order]]
   [[order.group]]
     id = "heroku/java"
-    version = "0.3.12"
+    version = "0.3.13"


### PR DESCRIPTION
## `heroku/jvm@0.1.11`
### Changed
* Default version for **OpenJDK 7** is now `1.7.0_322`
* Default version for **OpenJDK 17** is now `17.0.1`

## `heroku/java@0.3.13`
### Changed
* Upgraded `heroku/jvm` to `0.1.11`

## `heroku/java-function@0.3.24`
### Changed
* Upgraded `heroku/jvm` to `0.1.11`

References: 
[W-10084724](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00000JMShPYAX)
[W-10059481](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00000HyuojYAB)

[heroku/java-function](https://github.com/heroku/buildpacks-jvm/actions/runs/1395162894)
[heroku/java](https://github.com/heroku/buildpacks-jvm/actions/runs/1395265140)
[heroku/jvm](https://github.com/heroku/buildpacks-jvm/actions/runs/1395064639)
