### PR TITLE
Add automation for updating builder lifecycle version

### DIFF
--- a/.github/workflows/update-lifecycle.yml
+++ b/.github/workflows/update-lifecycle.yml
@@ -1,0 +1,71 @@
+name: Update lifecycle
+
+on:
+  schedule:
+    # Every Monday at 8am UTC.
+    - cron: '0 8 * * MON'
+  workflow_dispatch:
+
+jobs:
+  update-lifecycle:
+    name: Update lifecycle
+    runs-on: pub-hk-ubuntu-22.04-small
+    steps:
+      - name: Get token for GH application (Linguist)
+        uses: heroku/use-app-token-action@main
+        id: generate-token
+        with:
+          app_id: ${{ vars.LINGUIST_GH_APP_ID }}
+          private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate-token.outputs.app_token }}
+
+      - name: Record existing lifecycle version
+        id: existing-version
+        # Having to use grep instead of yq due to:
+        # https://github.com/mikefarah/yq/issues/1758
+        run: echo "version=$(grep --perl-regexp --null-data --only-matching '\[lifecycle\]\nversion = "\K([^"]+)' builder-22/builder.toml)" >> "${GITHUB_OUTPUT}"
+
+      - name: Determine latest lifecycle version
+        id: latest-version
+        run: echo "version=$(gh release view --repo buildpacks/lifecycle --json tagName --jq '.tagName | sub("v"; "")')" >> "${GITHUB_OUTPUT}"
+
+      - name: Update builder manifests with latest lifecycle version
+        # This only updates manifests that were on the same version as builder-22, to ensure
+        # that any legacy builder images pinned to older lifecycle versions are not updated too.
+        run: sed --in-place --expression 's/^version = "${{ steps.existing-version.outputs.version }}"$/version = "${{ steps.latest-version.outputs.version }}"/' */builder.toml
+
+      # This step will skip creating a PR if there are no changes to commit.
+      - name: Create pull request
+        id: pr
+        uses: peter-evans/create-pull-request@v5.0.2
+        with:
+          token: ${{ steps.generate-token.outputs.app_token }}
+          title: Update lifecycle from v${{ steps.existing-version.outputs.version }} to v${{ steps.latest-version.outputs.version }}
+          body: |
+            Release notes:
+            https://github.com/buildpacks/lifecycle/releases/tag/v${{ steps.latest-version.outputs.version }}
+
+            Full changelog:
+            https://github.com/buildpacks/lifecycle/compare/v${{ steps.existing-version.outputs.version }}...v${{ steps.latest-version.outputs.version }}
+          commit-message: |
+            Update lifecycle from v${{ steps.existing-version.outputs.version }} to v${{ steps.latest-version.outputs.version }}
+
+            Release notes:
+            https://github.com/buildpacks/lifecycle/releases/tag/v${{ steps.latest-version.outputs.version }}
+
+            Full changelog:
+            https://github.com/buildpacks/lifecycle/compare/v${{ steps.existing-version.outputs.version }}...v${{ steps.latest-version.outputs.version }}
+          branch: update-lifecycle
+          delete-branch: true
+          committer: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
+          author: ${{ vars.LINGUIST_GH_APP_USERNAME }} <${{ vars.LINGUIST_GH_APP_EMAIL }}>
+
+      - name: Enable PR auto-merge
+        if: steps.pr.outputs.pull-request-operation == 'created'
+        run: gh pr merge --auto --squash "${{ steps.pr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}


### PR DESCRIPTION
Previously we had to manually keep track of [upstream lifecycle releases](https://github.com/buildpacks/lifecycle/releases), and then open PRs to update the builder manifest for each builder with the new version. 

For example:
https://github.com/heroku/cnb-builder-images/pull/389

Now, every Monday at 8am UTC, a GitHub Actions job will check for updates, and open a PR if the latest lifecycle version is newer than that used by the `heroku/builder:22` builder. (This means lifecycle version pinning will be supported too for eg our legacy images, since only builder images on the latest version will end up being updated each time.)

This new workflow can also be triggered manually thanks to the `workflow_dispatch` annotation.

GUS-W-14329446.