### PR TITLE
Update display name of shimmed buildpacks

### DIFF
--- a/builder-classic-22/builder.toml
+++ b/builder-classic-22/builder.toml
@@ -10,27 +10,27 @@ version = "0.17.2"
 
 [[buildpacks]]
   id = "heroku/clojure"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/clojure?version=0.0.0&name=Clojure"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/clojure?version=0.0.0&name=Heroku+Clojure+(Shimmed)"
 
 [[buildpacks]]
   id = "heroku/go"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/go?version=0.0.0&name=Go"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/go?version=0.0.0&name=Heroku+Go+(Shimmed)"
 
 [[buildpacks]]
   id = "heroku/gradle"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/gradle?version=0.0.0&name=Gradle"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/gradle?version=0.0.0&name=Heroku+Gradle+(Shimmed)"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/java?version=0.0.0&name=Java"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/java?version=0.0.0&name=Heroku+Java+(Shimmed)"
 
 [[buildpacks]]
   id = "heroku/nodejs"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/nodejs?version=0.0.0&name=Node.js"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/nodejs?version=0.0.0&name=Heroku+Node.js+(Shimmed)"
 
 [[buildpacks]]
   id = "heroku/php"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/php?version=0.0.0&name=PHP"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/php?version=0.0.0&name=Heroku+PHP+(Shimmed)"
 
 [[buildpacks]]
   id = "heroku/procfile"
@@ -38,15 +38,15 @@ version = "0.17.2"
 
 [[buildpacks]]
   id = "heroku/python"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/python?version=0.0.0&name=Python"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/python?version=0.0.0&name=Heroku+Python+(Shimmed)"
 
 [[buildpacks]]
   id = "heroku/ruby"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/ruby?version=0.0.0&name=Ruby"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/ruby?version=0.0.0&name=Heroku+Ruby+(Shimmed)"
 
 [[buildpacks]]
   id = "heroku/scala"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/scala?version=0.0.0&name=Scala"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/scala?version=0.0.0&name=Heroku+Scala+(Shimmed)"
 
 [[order]]
   [[order.group]]

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -10,11 +10,11 @@ version = "0.17.2"
 
 [[buildpacks]]
   id = "heroku/go"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/go?version=0.0.0&name=Go"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/go?version=0.0.0&name=Heroku+Go+(Shimmed)"
 
 [[buildpacks]]
   id = "heroku/gradle"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/gradle?version=0.0.0&name=Gradle"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/gradle?version=0.0.0&name=Heroku+Gradle+(Shimmed)"
 
 [[buildpacks]]
   id = "heroku/java"
@@ -26,7 +26,7 @@ version = "0.17.2"
 
 [[buildpacks]]
   id = "heroku/php"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/php?version=0.0.0&name=PHP"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/php?version=0.0.0&name=Heroku+PHP+(Shimmed)"
 
 [[buildpacks]]
   id = "heroku/procfile"
@@ -34,15 +34,15 @@ version = "0.17.2"
 
 [[buildpacks]]
   id = "heroku/python"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/python?version=0.0.0&name=Python"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/python?version=0.0.0&name=Heroku+Python+(Shimmed)"
 
 [[buildpacks]]
   id = "heroku/ruby"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/ruby?version=0.0.0&name=Ruby"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/ruby?version=0.0.0&name=Heroku+Ruby+(Shimmed)"
 
 [[buildpacks]]
   id = "heroku/scala"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/scala?version=0.0.0&name=Scala"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/scala?version=0.0.0&name=Heroku+Scala+(Shimmed)"
 
 [[order]]
   [[order.group]]


### PR DESCRIPTION
So that:
- The naming style matches that chosen in #408
- It's clearer that these are shimmed buildpacks and not the native CNB versions of the buildpacks with the same name

I've inspected the contents of the generated archives to ensure that the URL unescaping works as expected.

GUS-W-14121598.