### PR TITLE
Stop testing against the TypeScript getting started guide

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         builder: ["buildpacks-20", "builder-classic-22", "builder-20", "builder-22"]
-        language: ["go", "gradle", "java", "node-js", "php", "python", "ruby", "scala", "typescript"]
+        language: ["go", "gradle", "java", "node-js", "php", "python", "ruby", "scala"]
         include:
           - builder: builder-classic-22
             language: clojure


### PR DESCRIPTION
Since:
- This guide isn't used by any Dev Center documentation: https://devcenter.heroku.com/search?q=typescript
- It's outdated (no updates for two years).
- TypeScript apps use the same `heroku/nodejs` CNB as JavaScript apps, and `heroku/nodejs` is already tested via the main Node.js getting started guide.
- The CI for this repo doesn't test multiple guides for any of the other supported languages.
- Removing it unblocks #417 (since the TypeScript guide is missing an NPM lockfile).

See also:
https://github.com/heroku/cnb-builder-images/pull/417#issuecomment-1779222791

GUS-W-14364069.