### PR TITLE
Stop publishing non-functions images to the internal registry

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -146,14 +146,12 @@ jobs:
         include:
           - builder: buildpacks-20
             tag_public: heroku/buildpacks:20
-            tag_private: heroku-20:builder
           - builder: builder-classic-22
             tag_public: heroku/builder-classic:22
           - builder: builder-20
             tag_public: heroku/builder:20
           - builder: builder-22
             tag_public: heroku/builder:22
-            tag_private: heroku-22:builder
           - builder: salesforce-functions
             tag_private: heroku-22:builder-functions
     steps:


### PR DESCRIPTION
The `heroku/buildpacks:20` and `heroku/builder:22` builders are now only published to Docker Hub, rather than also being published to the internal registry (where they were tagged as `heroku-20:builder` and `heroku-22:builder` respectively).

Kodon has not defaulted to these non-functions images from the internal registry for some time, and as of heroku/kodon#410 these images (and the internal registry) are no longer on the builder allow list, so it's not possible to manually select them using `project.toml`.

This change does not affect the functions-only image, which continues to be published to (and consumed by the functions-specific Kodon instance from) the internal registry.

GUS-W-14378185.