### PR TITLE
Add deprecation warnings to legacy builder images

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ The builder images use Heroku's [stack images](https://github.com/heroku/stack-i
 | Builder Image                                       | Base Image                                  | Status      |
 |-----------------------------------------------------|---------------------------------------------|-------------|
 | [`heroku/buildpacks:18`][buildpacks-tags]           | [`heroku/heroku:18-cnb-build`][heroku-tags] | End-of-life |
-| [`heroku/buildpacks:20`][buildpacks-tags]           | [`heroku/heroku:20-cnb-build`][heroku-tags] | Available   |
+| [`heroku/buildpacks:20`][buildpacks-tags]           | [`heroku/heroku:20-cnb-build`][heroku-tags] | Deprecated  |
 | [`heroku/builder:20`][builder-tags]                 | [`heroku/heroku:20-cnb-build`][heroku-tags] | Available   |
 | [`heroku/builder:22`][builder-tags]                 | [`heroku/heroku:22-cnb-build`][heroku-tags] | Recommended |
-| [`heroku/builder-classic:22`][builder-classic-tags] | [`heroku/heroku:22-cnb-build`][heroku-tags] | Available   |
+| [`heroku/builder-classic:22`][builder-classic-tags] | [`heroku/heroku:22-cnb-build`][heroku-tags] | Deprecated  |
 
 [`heroku/builder`][builder-tags] builder images feature Heroku's native Cloud Native Buildpacks. These buildpacks are optimized and make use of many CNB features. These builder images support Go, Java (Maven, Gradle), Node.js, PHP, Python, Ruby, Scala and Typescript codebases.
 

--- a/builder-classic-22/builder.toml
+++ b/builder-classic-22/builder.toml
@@ -9,6 +9,10 @@ run-image = "heroku/heroku:22-cnb"
 version = "0.17.2"
 
 [[buildpacks]]
+  id = "heroku/builder-eol-warning"
+  uri = "./end-of-life-buildpack/"
+
+[[buildpacks]]
   id = "heroku/clojure"
   uri = "https://cnb-shim.herokuapp.com/v1/heroku/clojure?version=0.0.0&name=Heroku+Clojure+(Shimmed)"
 
@@ -52,88 +56,106 @@ version = "0.17.2"
   [[order.group]]
     id = "heroku/ruby"
     version = "0.0.0"
-
   [[order.group]]
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
     id = "heroku/clojure"
     version = "0.0.0"
-
   [[order.group]]
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
     id = "heroku/python"
     version = "0.0.0"
-
   [[order.group]]
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
     id = "heroku/java"
     version = "0.0.0"
-
   [[order.group]]
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
     id = "heroku/gradle"
     version = "0.0.0"
-
   [[order.group]]
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
     id = "heroku/scala"
     version = "0.0.0"
-
   [[order.group]]
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
     id = "heroku/php"
     version = "0.0.0"
-
   [[order.group]]
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
     id = "heroku/go"
     version = "0.0.0"
-
   [[order.group]]
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
     id = "heroku/nodejs"
     version = "0.0.0"
-
   [[order.group]]
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "1.0.0"

--- a/builder-classic-22/end-of-life-buildpack/bin/build
+++ b/builder-classic-22/end-of-life-buildpack/bin/build
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function echo_stderr() {
+  local ansi_red="\033[1;31m"
+  local ansi_reset="\033[0m"
+  echo -e "\n${ansi_red}${1}${ansi_reset}\n" >&2
+}
+
+read -r -d '' EOL_MESSAGE <<'EOF' || true
+#######################################################################
+
+WARNING: This builder image (heroku/builder-classic:22) is deprecated,
+since it uses legacy shimmed classic Heroku buildpacks, rather than
+Heroku's next-generation Cloud Native Buildpacks.
+
+As such, this image is no longer supported and will soon stop receiving
+security updates.
+
+Please switch to one of our newer 'heroku/builder:*' builder images,
+such as 'heroku/builder:22':
+https://github.com/heroku/cnb-builder-images#heroku-cnb-builder-images
+
+If you are using the Pack CLI, you will need to adjust your '--builder'
+CLI argument, or else change the default builder configuration:
+https://buildpacks.io/docs/tools/pack/cli/pack_config_default-builder/
+
+If you are using a third-party platform to deploy your app, check their
+documentation for how to adjust the builder image used for your build.
+
+#######################################################################
+EOF
+
+echo_stderr "${EOL_MESSAGE}"
+exit 0

--- a/builder-classic-22/end-of-life-buildpack/bin/build
+++ b/builder-classic-22/end-of-life-buildpack/bin/build
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-function echo_stderr() {
+function display_error() {
   local ansi_red="\033[1;31m"
   local ansi_reset="\033[0m"
   echo -e "\n${ansi_red}${1}${ansi_reset}\n" >&2
@@ -32,5 +32,5 @@ documentation for how to adjust the builder image used for your build.
 #######################################################################
 EOF
 
-echo_stderr "${EOL_MESSAGE}"
+display_error "${EOL_MESSAGE}"
 exit 0

--- a/builder-classic-22/end-of-life-buildpack/bin/detect
+++ b/builder-classic-22/end-of-life-buildpack/bin/detect
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exit 0

--- a/builder-classic-22/end-of-life-buildpack/buildpack.toml
+++ b/builder-classic-22/end-of-life-buildpack/buildpack.toml
@@ -1,0 +1,8 @@
+api = "0.9"
+
+[buildpack]
+  id = "heroku/builder-eol-warning"
+  version = "1.0.0"
+
+[[stacks]]
+  id = "*"

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -9,6 +9,10 @@ run-image = "heroku/heroku:20-cnb"
 version = "0.17.2"
 
 [[buildpacks]]
+  id = "heroku/builder-eol-warning"
+  uri = "./end-of-life-buildpack/"
+
+[[buildpacks]]
   id = "heroku/go"
   uri = "https://cnb-shim.herokuapp.com/v1/heroku/go?version=0.0.0&name=Heroku+Go+(Shimmed)"
 
@@ -52,6 +56,9 @@ version = "0.17.2"
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
@@ -61,6 +68,9 @@ version = "0.17.2"
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
@@ -70,6 +80,9 @@ version = "0.17.2"
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
@@ -79,6 +92,9 @@ version = "0.17.2"
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
@@ -88,6 +104,9 @@ version = "0.17.2"
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
@@ -97,6 +116,9 @@ version = "0.17.2"
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
@@ -106,3 +128,6 @@ version = "0.17.2"
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "1.0.0"

--- a/buildpacks-20/end-of-life-buildpack/bin/build
+++ b/buildpacks-20/end-of-life-buildpack/bin/build
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function echo_stderr() {
+  local ansi_red="\033[1;31m"
+  local ansi_reset="\033[0m"
+  echo -e "\n${ansi_red}${1}${ansi_reset}\n" >&2
+}
+
+read -r -d '' EOL_MESSAGE <<'EOF' || true
+#######################################################################
+
+WARNING: This builder image (heroku/buildpacks:20) is deprecated,
+since it uses legacy shimmed classic Heroku buildpacks, rather than
+Heroku's next-generation Cloud Native Buildpacks.
+
+As such, this image is no longer supported and will soon stop receiving
+security updates.
+
+Please switch to one of our newer 'heroku/builder:*' builder images,
+such as 'heroku/builder:22':
+https://github.com/heroku/cnb-builder-images#heroku-cnb-builder-images
+
+If you are using the Pack CLI, you will need to adjust your '--builder'
+CLI argument, or else change the default builder configuration:
+https://buildpacks.io/docs/tools/pack/cli/pack_config_default-builder/
+
+If you are using a third-party platform to deploy your app, check their
+documentation for how to adjust the builder image used for your build.
+
+#######################################################################
+EOF
+
+echo_stderr "${EOL_MESSAGE}"
+exit 0

--- a/buildpacks-20/end-of-life-buildpack/bin/build
+++ b/buildpacks-20/end-of-life-buildpack/bin/build
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-function echo_stderr() {
+function display_error() {
   local ansi_red="\033[1;31m"
   local ansi_reset="\033[0m"
   echo -e "\n${ansi_red}${1}${ansi_reset}\n" >&2
@@ -32,5 +32,5 @@ documentation for how to adjust the builder image used for your build.
 #######################################################################
 EOF
 
-echo_stderr "${EOL_MESSAGE}"
+display_error "${EOL_MESSAGE}"
 exit 0

--- a/buildpacks-20/end-of-life-buildpack/bin/detect
+++ b/buildpacks-20/end-of-life-buildpack/bin/detect
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exit 0

--- a/buildpacks-20/end-of-life-buildpack/buildpack.toml
+++ b/buildpacks-20/end-of-life-buildpack/buildpack.toml
@@ -1,0 +1,8 @@
+api = "0.9"
+
+[buildpack]
+  id = "heroku/builder-eol-warning"
+  version = "1.0.0"
+
+[[stacks]]
+  id = "*"


### PR DESCRIPTION
Adds deprecation warnings to the `heroku/builder-classic:22` and `heroku/buildpacks:20` CNB builder images, to raise awareness that they are no longer supported/recommended.

The warnings have been added using a warnings buildpack, similar to the approach used for the Heroku-18 EOL in:
https://github.com/heroku/cnb-builder-images/pull/336

For now these are just warnings, however, in the future will be changed to an error (skippable via env var, like in the PR linked above).

Since these are warnings, the buildpack has been added to the end of each buildpack order group, such that the message is at the end of the overall build log, and so hopefully more visible to end users. (Once the warning is turned into an error, the buildpack should be moved to the start of the order groups, so the build fails early for improved UX.)

A separate mostly-copy-pasted buildpack was used for each builder, since there is no other easy way to customise the message shown for each (and I wanted to include the name of the deprecated builder in the warning message, so users know what image name to grep for).

These buildpacks were written in bash (rather than in Rust, using [libcnb.rs](https://github.com/heroku/libcnb.rs)), since:
- the buildpack functionality we need is extremely simple
- the buildpack is temporary (it will be deleted when we stop updating these builders in the future), so we don't need/want long term published images on CNB registry or to have to set up a Rust compilation/packaging step in this repo.

The buildpacks give zero lint warnings when checked with [shellcheck](https://github.com/koalaman/shellcheck) locally.

GUS-W-14194729.
GUS-W-14194736.