### PR TITLE
Add name, homepage and license to EOL buildpacks metadata

### DIFF
--- a/builder-classic-22/end-of-life-buildpack/buildpack.toml
+++ b/builder-classic-22/end-of-life-buildpack/buildpack.toml
@@ -3,6 +3,11 @@ api = "0.9"
 [buildpack]
   id = "heroku/builder-eol-warning"
   version = "1.0.0"
+  name = "Builder End-of-Life Warning"
+  homepage = "https://github.com/heroku/cnb-builder-images"
+
+[[buildpack.licenses]]
+  type = "BSD-3-Clause"
 
 [[stacks]]
   id = "*"

--- a/buildpacks-20/end-of-life-buildpack/buildpack.toml
+++ b/buildpacks-20/end-of-life-buildpack/buildpack.toml
@@ -3,6 +3,11 @@ api = "0.9"
 [buildpack]
   id = "heroku/builder-eol-warning"
   version = "1.0.0"
+  name = "Builder End-of-Life Warning"
+  homepage = "https://github.com/heroku/cnb-builder-images"
+
+[[buildpack.licenses]]
+  type = "BSD-3-Clause"
 
 [[stacks]]
   id = "*"


### PR DESCRIPTION
Amongst other reasons, this now means that `pack builder inspect` will no longer be missing the name/URL for the EOL buildpack.

Before:

```
Buildpacks:
  ID                                NAME                            VERSION        HOMEPAGE
  heroku/builder-eol-warning        -                               1.0.0          -
...
```

After:

```
Buildpacks:
  ID                                NAME                               VERSION        HOMEPAGE
  heroku/builder-eol-warning        Builder End-of-Life Warning        1.0.0          https://github.com/heroku/cnb-builder-images
...
```

Follow-up to #429.

GUS-W-14547289.