### PR TITLE
Use `--force-color` with `pack build` invocations

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Load Docker images into the Docker daemon
         run: zstd -dc --long=31 images.tar.zst | docker load
       - name: Build getting started guide image
-        run: pack build getting-started --builder ${{ matrix.builder }} --trust-builder --pull-policy never
+        run: pack build getting-started --force-color --builder ${{ matrix.builder }} --trust-builder --pull-policy never
       - name: Start getting started guide image
         # The `DYNO` env var is set to more accurately reflect the Heroku environment, since some of the getting
         # started guides use the presence of `DYNO` to determine whether to enable production mode or not.
@@ -122,7 +122,7 @@ jobs:
       - name: Load Docker images into the Docker daemon
         run: zstd -dc --long=31 images.tar.zst | docker load
       - name: Build example function image
-        run: pack build example-function --path salesforce-functions/examples/${{ matrix.language }} --builder ${{ matrix.builder }} --trust-builder --pull-policy never
+        run: pack build example-function --force-color --path salesforce-functions/examples/${{ matrix.language }} --builder ${{ matrix.builder }} --trust-builder --pull-policy never
       - name: Start example function image
         run: docker run --name example-function --detach -p 8080:8080 --env PORT=8080 --env DYNO=web.1 example-function
       - name: Test example function web server response


### PR DESCRIPTION
As of Pack 0.33.0 (which this repo is using thanks to #462), there is a new `--force-color` argument that makes `pack build` output logs in colour even if a TTY wasn't detected (as is the case on GHA):
https://github.com/buildpacks/pack/releases/tag/v0.33.0

This will allow us to see the colour output from the new build output implementation.

GUS-W-14968745.