### PR TITLE
Update lifecycle from v0.18.5 to v0.19.0-rc.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ For more information, see: [What is a builder?](https://buildpacks.io/docs/conce
 | [`heroku/buildpacks:18`][buildpacks-tags]           | [`heroku/heroku:18-cnb-build`][heroku-tags] | [`heroku/heroku:18-cnb`][heroku-tags] | 0.16.1            | Shimmed + Native | End-of-life |
 | [`heroku/buildpacks:20`][buildpacks-tags]           | [`heroku/heroku:20-cnb-build`][heroku-tags] | [`heroku/heroku:20-cnb`][heroku-tags] | 0.17.4            | Shimmed + Native | Deprecated  |
 | [`heroku/builder-classic:22`][builder-classic-tags] | [`heroku/heroku:22-cnb-build`][heroku-tags] | [`heroku/heroku:22-cnb`][heroku-tags] | 0.17.4            | Shimmed          | Deprecated  |
-| [`heroku/builder:20`][builder-tags]                 | [`heroku/heroku:20-cnb-build`][heroku-tags] | [`heroku/heroku:20-cnb`][heroku-tags] | 0.18.5            | Native           | Available   |
-| [`heroku/builder:22`][builder-tags]                 | [`heroku/heroku:22-cnb-build`][heroku-tags] | [`heroku/heroku:22-cnb`][heroku-tags] | 0.18.5            | Native           | Recommended |
+| [`heroku/builder:20`][builder-tags]                 | [`heroku/heroku:20-cnb-build`][heroku-tags] | [`heroku/heroku:20-cnb`][heroku-tags] | 0.19.0-rc.2       | Native           | Available   |
+| [`heroku/builder:22`][builder-tags]                 | [`heroku/heroku:22-cnb-build`][heroku-tags] | [`heroku/heroku:22-cnb`][heroku-tags] | 0.19.0-rc.2       | Native           | Recommended |
 
 The builder images above include buildpack support for the following languages: Go, Java, Node.js, PHP, Python, Ruby & Scala. The `heroku/builder-classic:22` builder image variant additionally supports Clojure.
 

--- a/builder-20/builder.toml
+++ b/builder-20/builder.toml
@@ -6,7 +6,7 @@ build-image = "heroku/heroku:20-cnb-build"
 run-image = "heroku/heroku:20-cnb"
 
 [lifecycle]
-version = "0.18.5"
+version = "0.19.0-rc.2"
 
 [[buildpacks]]
   id = "heroku/go"

--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -6,7 +6,7 @@ build-image = "heroku/heroku:22-cnb-build"
 run-image = "heroku/heroku:22-cnb"
 
 [lifecycle]
-version = "0.18.5"
+version = "0.19.0-rc.2"
 
 [[buildpacks]]
   id = "heroku/go"


### PR DESCRIPTION
This updates the builder images to the latest lifecycle version, `0.19.0-rc.2`, Which includes a fix to https://github.com/buildpacks/lifecycle/issues/1308. 

Internal conversation about this issue: https://salesforce-internal.slack.com/archives/C01R6FJ738U/p1709318630497849.