### PR TITLE
Fix broken upstream docs URL in deprecation message

### DIFF
--- a/builder-classic-22/end-of-life-buildpack/bin/build
+++ b/builder-classic-22/end-of-life-buildpack/bin/build
@@ -23,8 +23,8 @@ such as 'heroku/builder:22':
 https://github.com/heroku/cnb-builder-images#available-images
 
 If you are using the Pack CLI, you will need to adjust your '--builder'
-CLI argument, or else change the default builder configuration:
-https://buildpacks.io/docs/tools/pack/cli/pack_config_default-builder/
+CLI argument, or else change the default builder configuration using:
+'pack config default-builder <new_builder_name>'
 
 If you are using a third-party platform to deploy your app, check their
 documentation for how to adjust the builder image used for your build.

--- a/buildpacks-20/end-of-life-buildpack/bin/build
+++ b/buildpacks-20/end-of-life-buildpack/bin/build
@@ -23,8 +23,8 @@ such as 'heroku/builder:22':
 https://github.com/heroku/cnb-builder-images#available-images
 
 If you are using the Pack CLI, you will need to adjust your '--builder'
-CLI argument, or else change the default builder configuration:
-https://buildpacks.io/docs/tools/pack/cli/pack_config_default-builder/
+CLI argument, or else change the default builder configuration using:
+'pack config default-builder <new_builder_name>'
 
 If you are using a third-party platform to deploy your app, check their
 documentation for how to adjust the builder image used for your build.


### PR DESCRIPTION
The upstream CNB project has rearranged a number of the docs pages, breaking some existing links such as:
https://buildpacks.io/docs/tools/pack/cli/pack_config_default-builder/

I've filed https://github.com/buildpacks/docs/issues/673 for potentially adding redirects, however, for the deprecation warning use-case, it makes more sense for us to just inline the CLI command rather than link out to the docs.