### PR TITLE
Fix ANSI escape code wrapping of deprecation messages

### DIFF
--- a/builder-classic-22/end-of-life-buildpack/bin/build
+++ b/builder-classic-22/end-of-life-buildpack/bin/build
@@ -2,13 +2,20 @@
 
 set -euo pipefail
 
+ANSI_RED="\033[1;31m"
+ANSI_RESET="\033[0m"
+
 function display_error() {
-  local ansi_red="\033[1;31m"
-  local ansi_reset="\033[0m"
-  echo -e "\n${ansi_red}${1}${ansi_reset}\n" >&2
+  echo >&2
+  # We have to ANSI wrap each line separately to prevent breakage if line prefixes are added
+  # later (such as when the builder is untrusted, or when Git adds the "remote:" prefix).
+  while IFS= read -r line; do
+    echo -e "${ANSI_RED}${line}${ANSI_RESET}" >&2
+  done <<< "${1}"
+  echo >&2
 }
 
-read -r -d '' EOL_MESSAGE <<'EOF' || true
+display_error "$(cat <<'EOF'
 #######################################################################
 
 WARNING: This builder image (heroku/builder-classic:22) is deprecated,
@@ -31,6 +38,6 @@ documentation for how to adjust the builder image used for your build.
 
 #######################################################################
 EOF
+)"
 
-display_error "${EOL_MESSAGE}"
 exit 0

--- a/buildpacks-20/end-of-life-buildpack/bin/build
+++ b/buildpacks-20/end-of-life-buildpack/bin/build
@@ -2,13 +2,20 @@
 
 set -euo pipefail
 
+ANSI_RED="\033[1;31m"
+ANSI_RESET="\033[0m"
+
 function display_error() {
-  local ansi_red="\033[1;31m"
-  local ansi_reset="\033[0m"
-  echo -e "\n${ansi_red}${1}${ansi_reset}\n" >&2
+  echo >&2
+  # We have to ANSI wrap each line separately to prevent breakage if line prefixes are added
+  # later (such as when the builder is untrusted, or when Git adds the "remote:" prefix).
+  while IFS= read -r line; do
+    echo -e "${ANSI_RED}${line}${ANSI_RESET}" >&2
+  done <<< "${1}"
+  echo >&2
 }
 
-read -r -d '' EOL_MESSAGE <<'EOF' || true
+display_error "$(cat <<'EOF'
 #######################################################################
 
 WARNING: This builder image (heroku/buildpacks:20) is deprecated,
@@ -31,6 +38,6 @@ documentation for how to adjust the builder image used for your build.
 
 #######################################################################
 EOF
+)"
 
-display_error "${EOL_MESSAGE}"
 exit 0


### PR DESCRIPTION
Previously the colourisation of the deprecation messages would break if the output had prefixes added later (for example as happens when using an untrusted builder).

Now, each line is wrapped in its own colour code + reset code, which resolves the issue.

GUS-W-15212105.

#### Before:

<img width="590" alt="before" src="https://github.com/heroku/cnb-builder-images/assets/501702/a49637d7-8776-4f25-aa33-3f94d425c9a0">

#### After:

<img width="590" alt="after" src="https://github.com/heroku/cnb-builder-images/assets/501702/a41ff296-acfa-4ba9-b906-09d70f4ead58">
