### PR TITLE
Upgrade legacy builder deprecation warnings to errors

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Load Docker images into the Docker daemon
         run: zstd -dc --long=31 images.tar.zst | docker load
       - name: Build getting started guide image
-        run: pack build getting-started --force-color --builder ${{ matrix.builder }} --trust-builder --pull-policy never
+        run: pack build getting-started --force-color --builder ${{ matrix.builder }} --trust-builder --pull-policy never --env ALLOW_EOL_SHIMMED_BUILDER=1
       - name: Start getting started guide image
         # The `DYNO` env var is set to more accurately reflect the Heroku environment, since some of the getting
         # started guides use the presence of `DYNO` to determine whether to enable production mode or not.

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ For more information, see: [What is a builder?](https://buildpacks.io/docs/conce
 ## Available images
 
 > [!WARNING]
-> The `heroku/buildpacks:*` and `heroku/builder-classic:*` builder image variants are deprecated,
+> The `heroku/buildpacks:*` and `heroku/builder-classic:*` builder image variants have been sunset,
 > since they use classic Heroku buildpacks shimmed for compatibility with the CNB specification,
 > rather than Heroku's next-generation Cloud Native Buildpacks.
 
 | Builder Image                                       | Base Build Image                            | Base Run Image                        | Lifecycle Version | Buildpack Types  | Status      |
 |-----------------------------------------------------|---------------------------------------------|---------------------------------------|-------------------|------------------|-------------|
 | [`heroku/buildpacks:18`][buildpacks-tags]           | [`heroku/heroku:18-cnb-build`][heroku-tags] | [`heroku/heroku:18-cnb`][heroku-tags] | 0.16.1            | Shimmed + Native | End-of-life |
-| [`heroku/buildpacks:20`][buildpacks-tags]           | [`heroku/heroku:20-cnb-build`][heroku-tags] | [`heroku/heroku:20-cnb`][heroku-tags] | 0.17.5            | Shimmed + Native | Deprecated  |
-| [`heroku/builder-classic:22`][builder-classic-tags] | [`heroku/heroku:22-cnb-build`][heroku-tags] | [`heroku/heroku:22-cnb`][heroku-tags] | 0.17.5            | Shimmed          | Deprecated  |
+| [`heroku/buildpacks:20`][buildpacks-tags]           | [`heroku/heroku:20-cnb-build`][heroku-tags] | [`heroku/heroku:20-cnb`][heroku-tags] | 0.17.5            | Shimmed + Native | End-of-life |
+| [`heroku/builder-classic:22`][builder-classic-tags] | [`heroku/heroku:22-cnb-build`][heroku-tags] | [`heroku/heroku:22-cnb`][heroku-tags] | 0.17.5            | Shimmed          | End-of-life |
 | [`heroku/builder:20`][builder-tags]                 | [`heroku/heroku:20-cnb-build`][heroku-tags] | [`heroku/heroku:20-cnb`][heroku-tags] | 0.19.0            | Native           | Available   |
 | [`heroku/builder:22`][builder-tags]                 | [`heroku/heroku:22-cnb-build`][heroku-tags] | [`heroku/heroku:22-cnb`][heroku-tags] | 0.19.0            | Native           | Recommended |
 

--- a/builder-classic-22/builder.toml
+++ b/builder-classic-22/builder.toml
@@ -60,17 +60,20 @@ version = "0.17.5"
 
 [[order]]
   [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "2.0.0"
+  [[order.group]]
     id = "heroku/ruby"
     version = "0.0.0"
   [[order.group]]
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
-  [[order.group]]
-    id = "heroku/builder-eol-warning"
-    version = "1.0.0"
 
 [[order]]
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "2.0.0"
   [[order.group]]
     id = "heroku/clojure"
     version = "0.0.0"
@@ -78,11 +81,11 @@ version = "0.17.5"
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
-  [[order.group]]
-    id = "heroku/builder-eol-warning"
-    version = "1.0.0"
 
 [[order]]
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "2.0.0"
   [[order.group]]
     id = "heroku/python"
     version = "0.0.0"
@@ -90,11 +93,11 @@ version = "0.17.5"
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
-  [[order.group]]
-    id = "heroku/builder-eol-warning"
-    version = "1.0.0"
 
 [[order]]
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "2.0.0"
   [[order.group]]
     id = "heroku/java"
     version = "0.0.0"
@@ -102,11 +105,11 @@ version = "0.17.5"
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
-  [[order.group]]
-    id = "heroku/builder-eol-warning"
-    version = "1.0.0"
 
 [[order]]
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "2.0.0"
   [[order.group]]
     id = "heroku/gradle"
     version = "0.0.0"
@@ -114,11 +117,11 @@ version = "0.17.5"
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
-  [[order.group]]
-    id = "heroku/builder-eol-warning"
-    version = "1.0.0"
 
 [[order]]
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "2.0.0"
   [[order.group]]
     id = "heroku/scala"
     version = "0.0.0"
@@ -126,11 +129,11 @@ version = "0.17.5"
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
-  [[order.group]]
-    id = "heroku/builder-eol-warning"
-    version = "1.0.0"
 
 [[order]]
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "2.0.0"
   [[order.group]]
     id = "heroku/php"
     version = "0.0.0"
@@ -138,11 +141,11 @@ version = "0.17.5"
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
-  [[order.group]]
-    id = "heroku/builder-eol-warning"
-    version = "1.0.0"
 
 [[order]]
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "2.0.0"
   [[order.group]]
     id = "heroku/go"
     version = "0.0.0"
@@ -150,11 +153,11 @@ version = "0.17.5"
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
-  [[order.group]]
-    id = "heroku/builder-eol-warning"
-    version = "1.0.0"
 
 [[order]]
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "2.0.0"
   [[order.group]]
     id = "heroku/nodejs"
     version = "0.0.0"
@@ -162,6 +165,3 @@ version = "0.17.5"
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
-  [[order.group]]
-    id = "heroku/builder-eol-warning"
-    version = "1.0.0"

--- a/builder-classic-22/end-of-life-buildpack/bin/build
+++ b/builder-classic-22/end-of-life-buildpack/bin/build
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+ENV_DIR="${2}/env"
+ENV_VAR_NAME='ALLOW_EOL_SHIMMED_BUILDER'
+ALLOW_BUILD="$(cat "${ENV_DIR}/${ENV_VAR_NAME}" 2> /dev/null || true)"
+
 ANSI_RED="\033[1;31m"
 ANSI_RESET="\033[0m"
 
@@ -15,10 +19,20 @@ function display_error() {
   echo >&2
 }
 
-display_error "$(cat <<'EOF'
+if [[ "${ALLOW_BUILD}" == "1" ]]; then
+  MSG_PREFIX="WARNING"
+  MSG_FOOTER="Allowing the build to continue since ${ENV_VAR_NAME} is set."
+  EXIT_CODE=0
+else
+  MSG_PREFIX="ERROR"
+  MSG_FOOTER="To ignore this error, set the env var ${ENV_VAR_NAME} to 1."
+  EXIT_CODE=1
+fi
+
+display_error "$(cat <<EOF
 #######################################################################
 
-WARNING: This builder image (heroku/builder-classic:22) is deprecated,
+${MSG_PREFIX}: This builder image (heroku/builder-classic:22) has been sunset,
 since it uses legacy shimmed classic Heroku buildpacks, rather than
 Heroku's next-generation Cloud Native Buildpacks.
 
@@ -36,8 +50,10 @@ CLI argument, or else change the default builder configuration using:
 If you are using a third-party platform to deploy your app, check their
 documentation for how to adjust the builder image used for your build.
 
+${MSG_FOOTER}
+
 #######################################################################
 EOF
 )"
 
-exit 0
+exit ${EXIT_CODE}

--- a/builder-classic-22/end-of-life-buildpack/buildpack.toml
+++ b/builder-classic-22/end-of-life-buildpack/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.9"
 
 [buildpack]
   id = "heroku/builder-eol-warning"
-  version = "1.0.0"
+  version = "2.0.0"
   name = "Builder End-of-Life Warning"
   homepage = "https://github.com/heroku/cnb-builder-images"
 

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -56,17 +56,20 @@ version = "0.17.5"
 
 [[order]]
   [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "2.0.0"
+  [[order.group]]
     id = "heroku/ruby"
     version = "0.0.0"
   [[order.group]]
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
-  [[order.group]]
-    id = "heroku/builder-eol-warning"
-    version = "1.0.0"
 
 [[order]]
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "2.0.0"
   [[order.group]]
     id = "heroku/python"
     version = "0.0.0"
@@ -74,11 +77,11 @@ version = "0.17.5"
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
-  [[order.group]]
-    id = "heroku/builder-eol-warning"
-    version = "1.0.0"
 
 [[order]]
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "2.0.0"
   [[order.group]]
     id = "heroku/scala"
     version = "0.0.0"
@@ -86,11 +89,11 @@ version = "0.17.5"
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
-  [[order.group]]
-    id = "heroku/builder-eol-warning"
-    version = "1.0.0"
 
 [[order]]
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "2.0.0"
   [[order.group]]
     id = "heroku/php"
     version = "0.0.0"
@@ -98,11 +101,11 @@ version = "0.17.5"
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
-  [[order.group]]
-    id = "heroku/builder-eol-warning"
-    version = "1.0.0"
 
 [[order]]
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "2.0.0"
   [[order.group]]
     id = "heroku/go"
     version = "0.0.0"
@@ -110,11 +113,11 @@ version = "0.17.5"
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
-  [[order.group]]
-    id = "heroku/builder-eol-warning"
-    version = "1.0.0"
 
 [[order]]
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "2.0.0"
   [[order.group]]
     id = "heroku/nodejs"
     version = "3.0.1"
@@ -122,11 +125,11 @@ version = "0.17.5"
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
-  [[order.group]]
-    id = "heroku/builder-eol-warning"
-    version = "1.0.0"
 
 [[order]]
+  [[order.group]]
+    id = "heroku/builder-eol-warning"
+    version = "2.0.0"
   [[order.group]]
     id = "heroku/java"
     version = "4.1.0"
@@ -134,6 +137,3 @@ version = "0.17.5"
     id = "heroku/procfile"
     version = "2.0.2"
     optional = true
-  [[order.group]]
-    id = "heroku/builder-eol-warning"
-    version = "1.0.0"

--- a/buildpacks-20/end-of-life-buildpack/bin/build
+++ b/buildpacks-20/end-of-life-buildpack/bin/build
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+ENV_DIR="${2}/env"
+ENV_VAR_NAME='ALLOW_EOL_SHIMMED_BUILDER'
+ALLOW_BUILD="$(cat "${ENV_DIR}/${ENV_VAR_NAME}" 2> /dev/null || true)"
+
 ANSI_RED="\033[1;31m"
 ANSI_RESET="\033[0m"
 
@@ -15,10 +19,20 @@ function display_error() {
   echo >&2
 }
 
-display_error "$(cat <<'EOF'
+if [[ "${ALLOW_BUILD}" == "1" ]]; then
+  MSG_PREFIX="WARNING"
+  MSG_FOOTER="Allowing the build to continue since ${ENV_VAR_NAME} is set."
+  EXIT_CODE=0
+else
+  MSG_PREFIX="ERROR"
+  MSG_FOOTER="To ignore this error, set the env var ${ENV_VAR_NAME} to 1."
+  EXIT_CODE=1
+fi
+
+display_error "$(cat <<EOF
 #######################################################################
 
-WARNING: This builder image (heroku/buildpacks:20) is deprecated,
+${MSG_PREFIX}: This builder image (heroku/buildpacks:20) has been sunset,
 since it uses legacy shimmed classic Heroku buildpacks, rather than
 Heroku's next-generation Cloud Native Buildpacks.
 
@@ -36,8 +50,10 @@ CLI argument, or else change the default builder configuration using:
 If you are using a third-party platform to deploy your app, check their
 documentation for how to adjust the builder image used for your build.
 
+${MSG_FOOTER}
+
 #######################################################################
 EOF
 )"
 
-exit 0
+exit ${EXIT_CODE}

--- a/buildpacks-20/end-of-life-buildpack/buildpack.toml
+++ b/buildpacks-20/end-of-life-buildpack/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.9"
 
 [buildpack]
   id = "heroku/builder-eol-warning"
-  version = "1.0.0"
+  version = "2.0.0"
   name = "Builder End-of-Life Warning"
   homepage = "https://github.com/heroku/cnb-builder-images"
 


### PR DESCRIPTION
This upgrades the deprecation warnings added in #429 to errors, for the reasons mentioned in #474. It uses an approach similar to that used for the Heroku-18 EOL in #336.

These errors can be skipped by setting the env var: `ALLOW_EOL_SHIMMED_BUILDER=1`

For example:

`pack build --env ALLOW_EOL_SHIMMED_BUILDER=1 ...`

However, users are strongly encouraged to migrate from the legacy shimmed `heroku/buildpacks:20` and `heroku/builder-classic:22` images to the new `heroku/builder:*` builder images.

For the differences between the available images, see:
https://github.com/heroku/cnb-builder-images#available-images

The buildpack has also been moved to the start of each `[[order]]` group (rather than the end), so that the build fails early, rather than wasting the user/build system's time with a build that's only going to fail. (We had the buildpack at the end of the group before, to make the EOL warning more visible, since often users won't scroll back through the logs, and only see what's printed at the end of the build log in their console.)

Example error message:

<img width="537" alt="error-message" src="https://github.com/heroku/cnb-builder-images/assets/501702/99f380ab-37c0-486e-83f0-31725d4707ae">

See also:
https://github.com/heroku/cnb-builder-images/actions/runs/8204908398/job/22440626428?pr=478#step:6:30

Closes #474.
GUS-W-15212520.