### PR TITLE
Use older Pack CLI / Platform API for Functions tests

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -111,6 +111,12 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Pack CLI
         uses: buildpacks/github-actions/setup-pack@v5.5.3
+        with:
+          # Using an older version of Pack CLI here (that only supports Platform API <= 0.9),
+          # for testing parity with the Platform API version used by Kodon for Functions:
+          # https://github.com/buildpacks/pack/blob/v0.27.0/internal/build/lifecycle_executor.go#L30
+          # https://github.com/heroku/kodon/blob/functions_eol/internal/constants/constants.go#L75
+          pack-version: "0.27.0"
       - name: Restore Docker images from the cache
         uses: actions/cache/restore@v4
         with:
@@ -122,7 +128,7 @@ jobs:
       - name: Load Docker images into the Docker daemon
         run: zstd -dc --long=31 images.tar.zst | docker load
       - name: Build example function image
-        run: pack build example-function --force-color --path salesforce-functions/examples/${{ matrix.language }} --builder ${{ matrix.builder }} --trust-builder --pull-policy never
+        run: pack build example-function --path salesforce-functions/examples/${{ matrix.language }} --builder ${{ matrix.builder }} --trust-builder --pull-policy never
       - name: Start example function image
         run: docker run --name example-function --detach -p 8080:8080 --env PORT=8080 --env DYNO=web.1 example-function
       - name: Test example function web server response


### PR DESCRIPTION
The latest version of Pack CLI (v0.33.2) supports Platform API <= 0.12:
https://github.com/buildpacks/pack/blob/v0.33.2/internal/build/lifecycle_executor.go#L34

This means when it's used with any lifecycle version newer than 0.17.x, a `pack build` will end up using Platform API 0.12:
https://github.com/buildpacks/lifecycle#supported-apis

Therefore all of our tests in our CNB repos, and the smoke tests in this repo are all testing against Platform API 0.12.

However, Kodon is currently using Platform API 0.9, and whilst this is in the process of being upgraded (GUS-W-15122354), it's unlikely that the version will be upgraded for Kodon's `functions_eol` branch:
https://github.com/heroku/kodon/blob/functions_eol/internal/constants/constants.go#L75

As such, I've updated the functions tests here to use Pack CLI 0.27.0, which similarly only supports Platform API <= 0.9, and therefore gives us greater testing parity between CI and Kodon.

This test coverage will help catch things like:
https://github.com/buildpacks/lifecycle/pull/1309#issuecomment-1988929012

Downgrading the Pack CLI version meant needing to remove the `--force-color` arg, since it's only supported as of v0.33.0.

I've not changed the Pack CLI version used elsewhere, since it's helpful for us to also have coverage of the actual Pack CLI and Platform API versions everyone else will be using locally. (Plus hopefully Kodon's `main` branch will be upgraded to newer Platform API soon anyway.)

GUS-W-15226981.