### PR TITLE
Update Procfile CNB GitHub repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For buildpack-specific bugs or feature requests, file an issue against the appro
 - https://github.com/heroku/buildpacks-php
 - https://github.com/heroku/buildpacks-python
 - https://github.com/heroku/buildpacks-ruby
-- https://github.com/heroku/procfile-cnb
+- https://github.com/heroku/buildpacks-procfile
 
 For base image related bugs or feature requests (for example requests for additional system libraries), use:
 https://github.com/heroku/base-images


### PR DESCRIPTION
The `heroku/procfile` CNB GitHub repo has been renamed to:
https://github.com/heroku/buildpacks-procfile