### PR TITLE
Update lifecycle in legacy builders from v0.17.4 to v0.17.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ For more information, see: [What is a builder?](https://buildpacks.io/docs/conce
 | Builder Image                                       | Base Build Image                            | Base Run Image                        | Lifecycle Version | Buildpack Types  | Status      |
 |-----------------------------------------------------|---------------------------------------------|---------------------------------------|-------------------|------------------|-------------|
 | [`heroku/buildpacks:18`][buildpacks-tags]           | [`heroku/heroku:18-cnb-build`][heroku-tags] | [`heroku/heroku:18-cnb`][heroku-tags] | 0.16.1            | Shimmed + Native | End-of-life |
-| [`heroku/buildpacks:20`][buildpacks-tags]           | [`heroku/heroku:20-cnb-build`][heroku-tags] | [`heroku/heroku:20-cnb`][heroku-tags] | 0.17.4            | Shimmed + Native | Deprecated  |
-| [`heroku/builder-classic:22`][builder-classic-tags] | [`heroku/heroku:22-cnb-build`][heroku-tags] | [`heroku/heroku:22-cnb`][heroku-tags] | 0.17.4            | Shimmed          | Deprecated  |
+| [`heroku/buildpacks:20`][buildpacks-tags]           | [`heroku/heroku:20-cnb-build`][heroku-tags] | [`heroku/heroku:20-cnb`][heroku-tags] | 0.17.5            | Shimmed + Native | Deprecated  |
+| [`heroku/builder-classic:22`][builder-classic-tags] | [`heroku/heroku:22-cnb-build`][heroku-tags] | [`heroku/heroku:22-cnb`][heroku-tags] | 0.17.5            | Shimmed          | Deprecated  |
 | [`heroku/builder:20`][builder-tags]                 | [`heroku/heroku:20-cnb-build`][heroku-tags] | [`heroku/heroku:20-cnb`][heroku-tags] | 0.19.0            | Native           | Available   |
 | [`heroku/builder:22`][builder-tags]                 | [`heroku/heroku:22-cnb-build`][heroku-tags] | [`heroku/heroku:22-cnb`][heroku-tags] | 0.19.0            | Native           | Recommended |
 

--- a/builder-classic-22/builder.toml
+++ b/builder-classic-22/builder.toml
@@ -9,7 +9,7 @@ run-image = "heroku/heroku:22-cnb"
 # We have to use an older lifecycle version in this builder image since lifecycle 0.18.0
 # dropped support for Buildpack API versions <0.7, and cnb-shim is currently using v0.4:
 # https://github.com/heroku/cnb-shim/issues/69
-version = "0.17.4"
+version = "0.17.5"
 
 [[buildpacks]]
   id = "heroku/builder-eol-warning"

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -9,7 +9,7 @@ run-image = "heroku/heroku:20-cnb"
 # We have to use an older lifecycle version in this builder image since lifecycle 0.18.0
 # dropped support for Buildpack API versions <0.7, and cnb-shim is currently using v0.4:
 # https://github.com/heroku/cnb-shim/issues/69
-version = "0.17.4"
+version = "0.17.5"
 
 [[buildpacks]]
   id = "heroku/builder-eol-warning"

--- a/salesforce-functions/builder.toml
+++ b/salesforce-functions/builder.toml
@@ -11,7 +11,7 @@ run-image = "heroku/heroku:22-cnb"
 # - heroku/nodejs-function is still using the old Bash based NPM CNB (which is using Buildpack API 0.6)
 # - we know of at least one custom buildpack that's also using a legacy Buildpack API:
 #   https://github.com/CSGAMERSServices/puppeteer-heroku-buildpack
-version = "0.17.4"
+version = "0.17.5"
 
 [[buildpacks]]
   id = "heroku/java-function"


### PR DESCRIPTION
To pick up this backported fix:
https://github.com/buildpacks/lifecycle/pull/1317

...so that the legacy builder images still work when we have the next base image release - which will include this removal of the `CNB_TARGET_*` env vars workaround:
https://github.com/heroku/base-images/pull/260

Release notes:
https://github.com/buildpacks/lifecycle/releases/tag/v0.17.5

Full changelog:
https://github.com/buildpacks/lifecycle/compare/v0.17.4...v0.17.5

GUS-W-15225541.