### PR TITLE
Update EOL message shown for legacy builders

### DIFF
--- a/builder-classic-22/end-of-life-buildpack/bin/build
+++ b/builder-classic-22/end-of-life-buildpack/bin/build
@@ -36,11 +36,10 @@ ${MSG_PREFIX}: This builder image (heroku/builder-classic:22) has been sunset,
 since it uses legacy shimmed classic Heroku buildpacks, rather than
 Heroku's next-generation Cloud Native Buildpacks.
 
-As such, this image is no longer supported and will soon stop receiving
-security updates.
+As such, this image is no longer supported and does not receive any
+security updates or fixes.
 
-Please switch to one of our newer 'heroku/builder:*' builder images,
-such as 'heroku/builder:22':
+Please switch to one of our newer 'heroku/builder:*' builder images:
 https://github.com/heroku/cnb-builder-images#available-images
 
 If you are using the Pack CLI, you will need to adjust your '--builder'

--- a/buildpacks-20/end-of-life-buildpack/bin/build
+++ b/buildpacks-20/end-of-life-buildpack/bin/build
@@ -36,11 +36,10 @@ ${MSG_PREFIX}: This builder image (heroku/buildpacks:20) has been sunset,
 since it uses legacy shimmed classic Heroku buildpacks, rather than
 Heroku's next-generation Cloud Native Buildpacks.
 
-As such, this image is no longer supported and will soon stop receiving
-security updates.
+As such, this image is no longer supported and does not receive any
+security updates or fixes.
 
-Please switch to one of our newer 'heroku/builder:*' builder images,
-such as 'heroku/builder:22':
+Please switch to one of our newer 'heroku/builder:*' builder images:
 https://github.com/heroku/cnb-builder-images#available-images
 
 If you are using the Pack CLI, you will need to adjust your '--builder'


### PR DESCRIPTION
Updates the EOL message to reflect that we're now stopping updating these images. I've also removed the explicit builder image name example from the message, since it will get out of date once future builders are released.

The messaging has to be updated in this separate PR first, so we can do one more release with the new messaging before removing the publishing jobs in the next PR.

Towards #512.