### PR TITLE
Update status of `heroku/builder:24`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,21 @@ in each base image, see [this Dev Center article](https://devcenter.heroku.com/a
 
 ## Available images
 
-| Builder Image                     | OS           | Supported Architectures | Default Run Image                   | Lifecycle Version | Status         |
-|-----------------------------------|--------------|-------------------------|-------------------------------------|-------------------|----------------|
-| [heroku/builder:20][builder-tags] | Ubuntu 20.04 | AMD64                   | [heroku/heroku:20-cnb][heroku-tags] | 0.19.6            | Available      |
-| [heroku/builder:22][builder-tags] | Ubuntu 22.04 | AMD64                   | [heroku/heroku:22-cnb][heroku-tags] | 0.19.6            | Recommended    |
-| [heroku/builder:24][builder-tags] | Ubuntu 24.04 | AMD64 + ARM64           | [heroku/heroku:24][heroku-tags]     | 0.19.6            | In Development |
+| Builder Image                     | OS           | Supported Architectures | Default Run Image                   | Lifecycle Version | Status      |
+|-----------------------------------|--------------|-------------------------|-------------------------------------|-------------------|-------------|
+| [heroku/builder:20][builder-tags] | Ubuntu 20.04 | AMD64                   | [heroku/heroku:20-cnb][heroku-tags] | 0.19.6            | Available   |
+| [heroku/builder:22][builder-tags] | Ubuntu 22.04 | AMD64                   | [heroku/heroku:22-cnb][heroku-tags] | 0.19.6            | Available   |
+| [heroku/builder:24][builder-tags] | Ubuntu 24.04 | AMD64 + ARM64           | [heroku/heroku:24][heroku-tags]     | 0.19.6            | Recommended |
 
-The builder images above (excluding `heroku/builder:24`, whilst it's in development) include buildpack support for the following languages: Go, Java, Node.js, PHP, Python, Ruby & Scala.
+The builder images above include buildpack support for the following languages: Go, Java, Node.js, PHP, Python, Ruby & Scala.
 
 Check the [lifecycle API version support matrix](https://github.com/buildpacks/lifecycle#supported-apis) to determine
 which Platform and Buildpack API versions are compatible with the `lifecycle` version included in each builder.
 
 ## Usage
+
+> [!TIP]
+> For a more in-depth tutorial, see [Heroku Cloud Native Buildpacks](https://github.com/heroku/buildpacks).
 
 To build an app using these builder images locally:
 
@@ -35,19 +38,19 @@ To build an app using these builder images locally:
 2. Install the Pack CLI: https://buildpacks.io/docs/tools/pack/
 3. In your console, navigate to the directory containing your app and then run:
    ```term
-   pack build --builder heroku/builder:22 my-output-image-name
+   pack build --builder heroku/builder:24 my-output-image-name
    ```
 
 To avoid having to specify the `--builder` each time, you can set a
 [default builder](https://buildpacks.io/docs/tools/pack/cli/pack_config_default-builder/). For example:
 
 ```term
-pack config default-builder heroku/builder:22
+pack config default-builder heroku/builder:24
 ```
 
 ## Reporting issues
 
-For buildpack-specific bugs or feature requests, file an issue against the appropriate buildpack repository:
+For language/buildpack-specific bugs or feature requests, file an issue against the appropriate buildpack repository:
 
 - https://github.com/heroku/buildpacks-go
 - https://github.com/heroku/buildpacks-jvm
@@ -60,7 +63,10 @@ For buildpack-specific bugs or feature requests, file an issue against the appro
 For base image related bugs or feature requests (such as requests for additional system libraries), use:
 https://github.com/heroku/base-images
 
-For any other bug or feature request, file an issue in this repository.
+For builder image bugs (such as issues with the `lifecycle` version or buildpack detection order) file an issue in this repository.
+
+For anything else (including more general feature requests or questions), use:
+https://github.com/heroku/buildpacks/discussions
 
 [builder-tags]: https://hub.docker.com/r/heroku/builder/tags
 [heroku-tags]: https://hub.docker.com/r/heroku/heroku/tags

--- a/builder-20/builder.toml
+++ b/builder-20/builder.toml
@@ -1,4 +1,4 @@
-description = "Heroku-20 (Ubuntu 20.04) base image with buildpacks for Go, Java, Node.js, PHP, Python, Ruby & Scala."
+description = "Ubuntu 20.04 AMD64 base image with buildpacks for Go, Java, Node.js, PHP, Python, Ruby & Scala."
 
 [stack]
 id = "heroku-20"

--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -1,4 +1,4 @@
-description = "Heroku-22 (Ubuntu 22.04) base image with buildpacks for Go, Java, Node.js, PHP, Python, Ruby & Scala."
+description = "Ubuntu 22.04 AMD64 base image with buildpacks for Go, Java, Node.js, PHP, Python, Ruby & Scala."
 
 [stack]
 id = "heroku-22"

--- a/builder-24/builder.toml
+++ b/builder-24/builder.toml
@@ -1,4 +1,4 @@
-description = "Heroku-24 (Ubuntu 24.04) base image with buildpacks that support amd and arm architectures"
+description = "Ubuntu 24.04 AMD64+ARM64 base image with buildpacks for Go, Java, Node.js, PHP, Python, Ruby & Scala."
 
 [stack]
 id = "heroku-24"


### PR DESCRIPTION
Now that the PHP CNB supports Heroku-24 (incl ARM64) and has been added to `heroku/builder:24`, it means the `heroku/builder:24` builder is now complete (or at least as complete as our other builder images).

As such, we can:
- update the descriptions to mention it supports all languages
- mark `heroku/builder:24` as recommended and use it in the example usage instructions

I also spotted a few other small improvements that could be made to the README.

GUS-W-14686693.
GUS-W-14688185.