### PR TITLE
Mark `heroku/builder:20` as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ in each base image, see [this Dev Center article](https://devcenter.heroku.com/a
 
 | Builder Image                     | OS           | Supported Architectures | Default Run Image                   | Lifecycle Version | Status      |
 |-----------------------------------|--------------|-------------------------|-------------------------------------|-------------------|-------------|
-| [heroku/builder:20][builder-tags] | Ubuntu 20.04 | AMD64                   | [heroku/heroku:20-cnb][heroku-tags] | 0.19.7            | Available   |
+| [heroku/builder:20][builder-tags] | Ubuntu 20.04 | AMD64                   | [heroku/heroku:20-cnb][heroku-tags] | 0.19.7            | Deprecated  |
 | [heroku/builder:22][builder-tags] | Ubuntu 22.04 | AMD64                   | [heroku/heroku:22-cnb][heroku-tags] | 0.19.7            | Available   |
 | [heroku/builder:24][builder-tags] | Ubuntu 24.04 | AMD64 + ARM64           | [heroku/heroku:24][heroku-tags]     | 0.19.7            | Recommended |
 

--- a/builder-20/builder.toml
+++ b/builder-20/builder.toml
@@ -1,4 +1,4 @@
-description = "Ubuntu 20.04 AMD64 base image with buildpacks for Go, Java, Node.js, PHP, Python, Ruby & Scala."
+description = "[DEPRECATED] Ubuntu 20.04 AMD64 base image with buildpacks for Go, Java, Node.js, PHP, Python, Ruby & Scala."
 
 [stack]
 id = "heroku-20"


### PR DESCRIPTION
Per:
https://devcenter.heroku.com/changelog-items/2895

GUS-W-14701074.