### PR TITLE
Update CI to Ubuntu 24.04 runner images

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -35,7 +35,7 @@ jobs:
             arch: arm64
           - builder: salesforce-functions
             arch: arm64
-    runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-22.04-arm-medium' || 'ubuntu-22.04' }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-medium' || 'ubuntu-24.04' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -63,7 +63,7 @@ jobs:
           path: images.tar.zst
 
   test:
-    runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-22.04-arm-medium' || 'ubuntu-22.04' }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-medium' || 'ubuntu-24.04' }}
     needs: create
     strategy:
       fail-fast: false
@@ -113,7 +113,7 @@ jobs:
           fi
 
   test-functions:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: create
     strategy:
       fail-fast: false
@@ -156,7 +156,7 @@ jobs:
           fi
 
   publish-image:
-    runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-22.04-arm-medium' || 'ubuntu-22.04' }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-medium' || 'ubuntu-24.04' }}
     if: success() && github.ref == 'refs/heads/main'
     needs: ["test", "test-functions"]
     strategy:
@@ -218,7 +218,7 @@ jobs:
           docker push "${PRIVATE_IMAGE_URI}"
 
   publish-manifest:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: publish-image
     strategy:
       fail-fast: false

--- a/.github/workflows/update-lifecycle.yml
+++ b/.github/workflows/update-lifecycle.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   update-lifecycle:
     name: Update lifecycle
-    runs-on: pub-hk-ubuntu-22.04-small
+    runs-on: pub-hk-ubuntu-24.04-ip
     steps:
       - name: Get token for GH application (Linguist)
         uses: actions/create-github-app-token@v1


### PR DESCRIPTION
Now that Ubuntu 24.04 images are available on GitHub Actions, we can update from the Ubuntu 22.04 images.

See also:
https://github.com/actions/runner-images/issues/9848
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
https://salesforce.quip.com/bu6UA0KImOxJ#temp:C:GZRd13d2ce2d455470495cbd34cf

GUS-W-16238120.