### PR TITLE
Add deprecation messaging to builder:20

### DIFF
--- a/builder-20/builder.toml
+++ b/builder-20/builder.toml
@@ -9,6 +9,10 @@ run-image = "heroku/heroku:20-cnb"
 version = "0.19.7"
 
 [[buildpacks]]
+  id = "heroku/eol-warning"
+  uri = "./eol-buildpack/"
+
+[[buildpacks]]
   id = "heroku/go"
   uri = "docker://docker.io/heroku/buildpack-go@sha256:5b9434437add557c6a2cb7ad528480bacbde8a9ca9c5b3750c79ccb7c30afabd"
 
@@ -40,6 +44,7 @@ version = "0.19.7"
   id = "heroku/scala"
   uri = "docker://docker.io/heroku/buildpack-scala@sha256:0c50dda170abd417da3aadde8dd7be5f1e724f6b87137a730e946d814c6b9e92"
 
+
 [[order]]
   [[order.group]]
     id = "heroku/python"
@@ -48,6 +53,9 @@ version = "0.19.7"
     id = "heroku/procfile"
     version = "3.1.2"
     optional = true
+  [[order.group]]
+    id = "heroku/eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
@@ -69,6 +77,9 @@ version = "0.19.7"
     id = "heroku/procfile"
     version = "3.1.2"
     optional = true
+  [[order.group]]
+    id = "heroku/eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
@@ -78,6 +89,9 @@ version = "0.19.7"
     id = "heroku/procfile"
     version = "3.1.2"
     optional = true
+  [[order.group]]
+    id = "heroku/eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
@@ -87,6 +101,9 @@ version = "0.19.7"
     id = "heroku/procfile"
     version = "3.1.2"
     optional = true
+  [[order.group]]
+    id = "heroku/eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
@@ -96,6 +113,9 @@ version = "0.19.7"
     id = "heroku/procfile"
     version = "3.1.2"
     optional = true
+  [[order.group]]
+    id = "heroku/eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
@@ -105,6 +125,9 @@ version = "0.19.7"
     id = "heroku/procfile"
     version = "3.1.2"
     optional = true
+  [[order.group]]
+    id = "heroku/eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
@@ -114,3 +137,6 @@ version = "0.19.7"
     id = "heroku/procfile"
     version = "3.1.2"
     optional = true
+  [[order.group]]
+    id = "heroku/eol-warning"
+    version = "1.0.0"

--- a/builder-20/builder.toml
+++ b/builder-20/builder.toml
@@ -44,7 +44,6 @@ version = "0.19.7"
   id = "heroku/scala"
   uri = "docker://docker.io/heroku/buildpack-scala@sha256:0c50dda170abd417da3aadde8dd7be5f1e724f6b87137a730e946d814c6b9e92"
 
-
 [[order]]
   [[order.group]]
     id = "heroku/python"

--- a/builder-20/eol-buildpack/bin/build
+++ b/builder-20/eol-buildpack/bin/build
@@ -32,7 +32,7 @@ unavailable.
 To continue receiving security updates and avoid interruption, upgrade
 to one of our newer builders, such as 'heroku/builder:22' or
 'heroku/builder:24':
-https://github.com/heroku/cnb-builder-images#heroku-cnb-builder-images
+https://github.com/heroku/cnb-builder-images#available-images
 
 If you are using the Pack CLI, you will need to adjust your '--builder'
 CLI argument or change the default builder configuration:

--- a/builder-20/eol-buildpack/bin/build
+++ b/builder-20/eol-buildpack/bin/build
@@ -2,15 +2,15 @@
 
 set -euo pipefail
 
+ANSI_RED="\033[1;31m"
+ANSI_RESET="\033[0m"
+
 function display_error() {
-  local ansi_red="\033[1;31m"
-  local ansi_reset="\033[0m"
-  local message=$1
-  echo
+  echo >&2
   while IFS= read -r line; do
-    echo -e "${ansi_red}${line}${ansi_reset}" >&2
-  done <<< "$message"
-  echo
+    echo -e "${ANSI_RED}${line}${ANSI_RESET}" >&2
+  done <<< "${1}"
+  echo >&2
 }
 
 read -r -d '' EOL_MESSAGE <<'EOF' || true
@@ -44,4 +44,5 @@ platform documentation for instructions on changing the builder.
 EOF
 
 display_error "${EOL_MESSAGE}"
+
 exit 0

--- a/builder-20/eol-buildpack/bin/build
+++ b/builder-20/eol-buildpack/bin/build
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function display_error() {
+  local ansi_red="\033[1;31m"
+  local ansi_reset="\033[0m"
+  local message=$1
+  echo
+  while IFS= read -r line; do
+    echo -e "${ansi_red}${line}${ansi_reset}" >&2
+  done <<< "$message"
+  echo
+}
+
+read -r -d '' EOL_MESSAGE <<'EOF' || true
+#######################################################################
+ _                    _               ___   ___    ______ ____  _
+| |                  | |             |__ \ / _ \  |  ____/ __ \| |
+| |__   ___ _ __ ___ | | ___   _ ______ ) | | | | | |__ | |  | | |
+| '_ \ / _ \ '__/ _ \| |/ / | | |______/ /| | | | |  __|| |  | | |
+| | | |  __/ | | (_) |   <| |_| |     / /_| |_| | | |___| |__| | |____
+|_| |_|\___|_|  \___/|_|\_\\\__,_|    |____|\___/  |______\____/|______|
+
+This builder image ('heroku/bulder:20') is deprecated, since it is
+based on the deprecated 'heroku/heroku:20' base image.
+
+Starting April 30th, 2025, this image will no longer receive security
+updates. Shortly after, this builder will be disabled and made
+unavailable.
+
+To continue receiving security updates and avoid interruption, upgrade
+to one of our newer builders, such as 'heroku/builder:22' or
+'heroku/builder:24':
+https://github.com/heroku/cnb-builder-images#heroku-cnb-builder-images
+
+If you are using the Pack CLI, you will need to adjust your '--builder'
+CLI argument or change the default builder configuration:
+https://buildpacks.io/docs/tools/pack/cli/pack_config_default-builder/
+
+If you are using a third-party platform to deploy your app, check the
+platform documentation for instructions on changing the builder.
+#######################################################################
+EOF
+
+display_error "${EOL_MESSAGE}"
+exit 0

--- a/builder-20/eol-buildpack/bin/build
+++ b/builder-20/eol-buildpack/bin/build
@@ -13,6 +13,8 @@ function display_error() {
   echo >&2
 }
 
+# Banner generated via https://www.ascii-art-generator.org/ with "big" font
+# and 70 width.
 read -r -d '' EOL_MESSAGE <<'EOF' || true
 #######################################################################
  _                    _               ___   ___    ______ ____  _

--- a/builder-20/eol-buildpack/bin/detect
+++ b/builder-20/eol-buildpack/bin/detect
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exit 0

--- a/builder-20/eol-buildpack/buildpack.toml
+++ b/builder-20/eol-buildpack/buildpack.toml
@@ -1,0 +1,8 @@
+api = "0.9"
+
+[buildpack]
+  id = "heroku/eol-warning"
+  version = "1.0.0"
+
+[[stacks]]
+  id = "*"

--- a/builder-20/eol-buildpack/buildpack.toml
+++ b/builder-20/eol-buildpack/buildpack.toml
@@ -3,3 +3,8 @@ api = "0.10"
 [buildpack]
   id = "heroku/eol-warning"
   version = "1.0.0"
+  name = "heroku/builder:20 End-of-Life Warning"
+  homepage = "https://github.com/heroku/cnb-builder-images"
+
+[[buildpack.licenses]]
+  type = "BSD-3-Clause"

--- a/builder-20/eol-buildpack/buildpack.toml
+++ b/builder-20/eol-buildpack/buildpack.toml
@@ -3,6 +3,3 @@ api = "0.10"
 [buildpack]
   id = "heroku/eol-warning"
   version = "1.0.0"
-
-[[stacks]]
-  id = "*"

--- a/builder-20/eol-buildpack/buildpack.toml
+++ b/builder-20/eol-buildpack/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.9"
+api = "0.10"
 
 [buildpack]
   id = "heroku/eol-warning"


### PR DESCRIPTION
This adds a deprecation message to all builds using `heroku/builder:20`. 

Since this builder is based on the now deprecated `heroku/heroku:20` ([changelog entry](https://devcenter.heroku.com/changelog-items/2895)), security updates for `heroku/builder:20` will stop April 30, 2025. This messaging should encourage folks to update to a newer builder so that they may keep getting security updates and avoid interruption.

Example pack output:
<img width="647" alt="Pack CLI output" src="https://github.com/user-attachments/assets/61ad2b1a-b33a-4962-9440-6eedd440637c">



[heroku-20 EOL plan]( https://salesforce.quip.com/ss13A0jDWb7a)
[GUS](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001gotTdYAI/view)