### PR TITLE
Copy builder images to public ecr

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -235,7 +235,7 @@ jobs:
       - name: Tag builder and push to public ECR
         if: matrix.tag_ecr_public != ''
         run: |
-          ECR_PUBLIC_IMAGE_URI='public.ecr.ams/${{ matrix.tag_ecr_public }}'
+          ECR_PUBLIC_IMAGE_URI='public.ecr.aws/${{ matrix.tag_ecr_public }}'
           set -x
           docker tag '${{ matrix.builder }}' "${ECR_PUBLIC_IMAGE_URI}"
           docker push "${ECR_PUBLIC_IMAGE_URI}"

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -165,19 +165,22 @@ jobs:
         include:
           - builder: builder-20
             arch: amd64
-            tag_public: heroku/builder:20
+            tag_docker_hub: heroku/builder:20
           - builder: builder-22
             arch: amd64
-            tag_public: heroku/builder:22
+            tag_docker_hub: heroku/builder:22
+            tag_ecr_public: heroku/builder:22
           - builder: salesforce-functions
             arch: amd64
             tag_private: heroku-22:builder-functions
           - builder: builder-24
             arch: amd64
-            tag_public: heroku/builder:24_linux-amd64
+            tag_docker_hub: heroku/builder:24_linux-amd64
+            tag_ecr_public: heroku/builder:24_linux-amd64
           - builder: builder-24
             arch: arm64
-            tag_public: heroku/builder:24_linux-arm64
+            tag_docker_hub: heroku/builder:24_linux-arm64
+            tag_ecr_public: heroku/builder:24_linux-arm64
     steps:
       - name: Restore Docker images from the cache
         uses: actions/cache/restore@v4
@@ -190,7 +193,7 @@ jobs:
       - name: Load Docker images into the Docker daemon
         run: zstd -dc --long=31 images.tar.zst | docker load
       - name: Log into Docker Hub
-        if: matrix.tag_public != ''
+        if: matrix.tag_docker_hub != ''
         run: echo '${{ secrets.DOCKER_HUB_TOKEN }}' | docker login -u '${{ secrets.DOCKER_HUB_USER }}' --password-stdin
       - name: Log into internal registry
         if: matrix.tag_private != ''
@@ -202,13 +205,25 @@ jobs:
               | jq --exit-status -r '.raw_id_token'
           )
           echo "${REGISTRY_TOKEN}" | docker login '${{ secrets.REGISTRY_HOST }}' -u '${{ secrets.REGISTRY_USER }}' --password-stdin
+      - name: Configure AWS credentials
+        if: matrix.tag_ecr_public != ''
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ config.aws_account_id }}:role/${{ config.aws_ecr_role }}
+          aws-region: aws-region-1
+      - name: Login to Amazon ECR Public
+        if: matrix.tag_ecr_public != ''
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
       - name: Tag builder and push to Docker Hub
-        if: matrix.tag_public != ''
+        if: matrix.tag_docker_hub != ''
         run: |
-          PUBLIC_IMAGE_URI='${{ matrix.tag_public }}'
+          DOCKER_HUB_IMAGE_URI='${{ matrix.tag_docker_hub }}'
           set -x
-          docker tag '${{ matrix.builder }}' "${PUBLIC_IMAGE_URI}"
-          docker push "${PUBLIC_IMAGE_URI}"
+          docker tag '${{ matrix.builder }}' "${DOCKER_HUB_IMAGE_URI}"
+          docker push "${DOCKER_HUB_IMAGE_URI}"
       - name: Tag builder and push to internal registry
         if: matrix.tag_private != ''
         run: |
@@ -216,6 +231,13 @@ jobs:
           set -x
           docker tag '${{ matrix.builder }}' "${PRIVATE_IMAGE_URI}"
           docker push "${PRIVATE_IMAGE_URI}"
+      - name: Tag builder and push to public ECR
+        if: matrix.tag_ecr_public != ''
+        run: |
+          ECR_PUBLIC_IMAGE_URI='public.ecr.amazonaws.com/${{ matrix.tag_ecr_public }}'
+          set -x
+          docker tag '${{ matrix.builder }}' "${ECR_PUBLIC_IMAGE_URI}"
+          docker push "${ECR_PUBLIC_IMAGE_URI}"
 
   publish-manifest:
     runs-on: ubuntu-24.04
@@ -224,13 +246,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - tag_public: "heroku/builder:24"
+          - tag_docker_hub: "heroku/builder:24"
             manifests: "heroku/builder:24_linux-amd64 heroku/builder:24_linux-arm64"
     steps:
       - name: Log in to Docker Hub
-        if: matrix.tag_public != ''
+        if: matrix.tag_docker_hub != ''
         run: echo '${{ secrets.DOCKER_HUB_TOKEN }}' | docker login -u '${{ secrets.DOCKER_HUB_USER }}' --password-stdin
       - name: Create and push manifest lists
         run: |
-          docker manifest create "${{ matrix.tag_public }}" ${{ matrix.manifests }}
-          docker manifest push "${{ matrix.tag_public }}"
+          docker manifest create "${{ matrix.tag_docker_hub }}" ${{ matrix.manifests }}
+          docker manifest push "${{ matrix.tag_docker_hub }}"

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -210,7 +210,7 @@ jobs:
         if: matrix.tag_ecr_public != ''
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ config.aws_account_id }}:role/${{ config.aws_ecr_role }}
+          role-to-assume: arn:aws:iam::${{ config.AWS_ACCOUNT_ID }}:role/${{ config.AWS_ECR_ROLE }}
           aws-region: aws-region-1
       - name: Login to Amazon ECR Public
         if: matrix.tag_ecr_public != ''

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -210,8 +210,8 @@ jobs:
         if: matrix.tag_ecr_public != ''
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/${{ vars.AWS_ECR_ROLE }}
-          aws-region: aws-region-1
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_ECR_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
       - name: Login to Amazon ECR Public
         if: matrix.tag_ecr_public != ''
         id: login-ecr-public

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -210,7 +210,7 @@ jobs:
         if: matrix.tag_ecr_public != ''
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ config.AWS_ACCOUNT_ID }}:role/${{ config.AWS_ECR_ROLE }}
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/${{ vars.AWS_ECR_ROLE }}
           aws-region: aws-region-1
       - name: Login to Amazon ECR Public
         if: matrix.tag_ecr_public != ''

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -158,7 +158,7 @@ jobs:
 
   publish-image:
     runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-medium' || 'ubuntu-24.04' }}
-    if: success() && github.ref == 'refs/heads/public-ecr'
+    if: success() # && github.ref == 'refs/heads/main'
     needs: ["test", "test-functions"]
     strategy:
       fail-fast: false

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -158,7 +158,7 @@ jobs:
 
   publish-image:
     runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-medium' || 'ubuntu-24.04' }}
-    if: success() # && github.ref == 'refs/heads/main'
+    if: success() && github.ref == 'refs/heads/main'
     needs: ["test", "test-functions"]
     strategy:
       fail-fast: false

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -158,7 +158,7 @@ jobs:
 
   publish-image:
     runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-medium' || 'ubuntu-24.04' }}
-    if: success() && github.ref == 'refs/heads/main'
+    if: success() && github.ref == 'refs/heads/public-ecr'
     needs: ["test", "test-functions"]
     strategy:
       fail-fast: false

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 defaults:
   run:

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -212,7 +212,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_ECR_ROLE }}
           aws-region: ${{ vars.AWS_REGION }}
-      - name: Login to Amazon ECR Public
+      - name: Log in to Amazon ECR Public
         if: matrix.tag_ecr_public != ''
         id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v2
@@ -240,43 +240,32 @@ jobs:
           docker tag '${{ matrix.builder }}' "${ECR_PUBLIC_IMAGE_URI}"
           docker push "${ECR_PUBLIC_IMAGE_URI}"
 
-  publish-manifest:
+  publish-manifests:
     runs-on: ubuntu-24.04
     needs: publish-image
     strategy:
       fail-fast: false
       matrix:
         include:
-          - tag_docker_hub: "heroku/builder:24"
-            tag_ecr_public: "heroku/builder:24"
-            manifests: "heroku/builder:24_linux-amd64 heroku/builder:24_linux-arm64"
+          - tag_uri: "docker.io/heroku/builder:24"
+            manifest_uris: "docker.io/heroku/builder:24_linux-amd64 docker.io/heroku/builder:24_linux-arm64"
+          - tag_uri: "public.aws.ecr/heroku/builder:24"
+            manifest_uris: "public.aws.ecr/heroku/builder:24_linux-amd64 public.aws.ecr/heroku/builder:24_linux-arm64"
     steps:
       - name: Log in to Docker Hub
-        if: matrix.tag_docker_hub != ''
         run: echo '${{ secrets.DOCKER_HUB_TOKEN }}' | docker login -u '${{ secrets.DOCKER_HUB_USER }}' --password-stdin
       - name: Configure AWS credentials
-        if: matrix.tag_ecr_public != ''
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_ECR_ROLE }}
           aws-region: ${{ vars.AWS_REGION }}
-      - name: Login to Amazon ECR Public
-        if: matrix.tag_ecr_public != ''
+      - name: Log in to Amazon ECR Public
         id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v2
         with:
           registry-type: public
-      - name: Create and push manifest lists to Docker Hub
-        if: matrix.tag_docker_hub != ''
+      - name: Create and push manifest lists
         run: |
-          DOCKER_HUB_IMAGE_URI='${{ matrix.tag_docker_hub }}'
           set -x
-          docker manifest create "$DOCKER_HUB_IMAGE_URI" ${{ matrix.manifests }}
-          docker manifest push "$DOCKER_HUB_IMAGE_URI"
-      - name: Create and push manifest lists to public ECR
-        if: matrix.tag_ecr_public != ''
-        run: |
-          ECR_PUBLIC_IMAGE_URI='public.ecr.aws/${{ matrix.tag_ecr_public }}'
-          set -x
-          docker manifest create "$ECR_PUBLIC_IMAGE_URI" ${{ matrix.manifests }}
-          docker manifest push "$ECR_PUBLIC_IMAGE_URI"
+          docker manifest create "${{ matrix.tag_uri }}" ${{ matrix.manifest_uris }}
+          docker manifest push "${{ matrix.tag_uri }}"

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -235,7 +235,7 @@ jobs:
       - name: Tag builder and push to public ECR
         if: matrix.tag_ecr_public != ''
         run: |
-          ECR_PUBLIC_IMAGE_URI='public.ecr.amazonaws.com/${{ matrix.tag_ecr_public }}'
+          ECR_PUBLIC_IMAGE_URI='public.ecr.ams/${{ matrix.tag_ecr_public }}'
           set -x
           docker tag '${{ matrix.builder }}' "${ECR_PUBLIC_IMAGE_URI}"
           docker push "${ECR_PUBLIC_IMAGE_URI}"

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -248,12 +248,35 @@ jobs:
       matrix:
         include:
           - tag_docker_hub: "heroku/builder:24"
+            tag_public_ecr: "heroku/builder:24"
             manifests: "heroku/builder:24_linux-amd64 heroku/builder:24_linux-arm64"
     steps:
       - name: Log in to Docker Hub
         if: matrix.tag_docker_hub != ''
         run: echo '${{ secrets.DOCKER_HUB_TOKEN }}' | docker login -u '${{ secrets.DOCKER_HUB_USER }}' --password-stdin
-      - name: Create and push manifest lists
+      - name: Configure AWS credentials
+        if: matrix.tag_ecr_public != ''
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_ECR_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+      - name: Login to Amazon ECR Public
+        if: matrix.tag_ecr_public != ''
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+      - name: Create and push manifest lists to Docker Hub
+        if: matrix.tag_docker_hub != ''
         run: |
-          docker manifest create "${{ matrix.tag_docker_hub }}" ${{ matrix.manifests }}
-          docker manifest push "${{ matrix.tag_docker_hub }}"
+          DOCKER_HUB_IMAGE_URI='${{ matrix.tag_docker_hub }}'
+          set -x
+          docker manifest create "$DOCKER_HUB_IMAGE_URI" ${{ matrix.manifests }}
+          docker manifest push "$DOCKER_HUB_IMAGE_URI"
+      - name: Create and push manifest lists to public ECR
+        if: matrix.tag_ecr_public != ''
+        run: |
+          ECR_PUBLIC_IMAGE_URI='public.ecr.aws/${{ matrix.tag_ecr_public }}'
+          set -x
+          docker manifest create "$ECR_PUBLIC_IMAGE_URI" ${{ matrix.manifests }}
+          docker manifest push "$ECR_PUBLIC_IMAGE_URI"

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -240,7 +240,7 @@ jobs:
           docker tag '${{ matrix.builder }}' "${ECR_PUBLIC_IMAGE_URI}"
           docker push "${ECR_PUBLIC_IMAGE_URI}"
 
-  publish-manifests:
+  publish-manifest:
     runs-on: ubuntu-24.04
     needs: publish-image
     strategy:

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -248,7 +248,7 @@ jobs:
       matrix:
         include:
           - tag_docker_hub: "heroku/builder:24"
-            tag_public_ecr: "heroku/builder:24"
+            tag_ecr_public: "heroku/builder:24"
             manifests: "heroku/builder:24_linux-amd64 heroku/builder:24_linux-arm64"
     steps:
       - name: Log in to Docker Hub

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -249,8 +249,8 @@ jobs:
         include:
           - tag_uri: "docker.io/heroku/builder:24"
             manifest_uris: "docker.io/heroku/builder:24_linux-amd64 docker.io/heroku/builder:24_linux-arm64"
-          - tag_uri: "public.aws.ecr/heroku/builder:24"
-            manifest_uris: "public.aws.ecr/heroku/builder:24_linux-amd64 public.aws.ecr/heroku/builder:24_linux-arm64"
+          - tag_uri: "public.ecr.aws/heroku/builder:24"
+            manifest_uris: "public.ecr.aws/heroku/builder:24_linux-amd64 public.ecr.aws/heroku/builder:24_linux-arm64"
     steps:
       - name: Log in to Docker Hub
         run: echo '${{ secrets.DOCKER_HUB_TOKEN }}' | docker login -u '${{ secrets.DOCKER_HUB_USER }}' --password-stdin


### PR DESCRIPTION
This PR changes the publish automation to additionally push builder images to `public.ecr.aws/heroku/builder`. This aims to alleviate some Docker Hub rate limit concerns and enables faster downloads in some cloud environments. The primary and canonical location for these images is still `heroku/builder` (on dockerhub).

This automation makes use of GitHub OIDC to authenticate with AWS so no IAM users or access tokens are in use.

[GUS](https://gus.lightning.force.com/a07EE00001qVbCRYA0)