### PR TITLE
Specify run image mirrorrs

### DIFF
--- a/builder-20/builder.toml
+++ b/builder-20/builder.toml
@@ -2,8 +2,17 @@ description = "[DEPRECATED] Ubuntu 20.04 AMD64 base image with buildpacks for Go
 
 [stack]
 id = "heroku-20"
-build-image = "heroku/heroku:20-cnb-build"
-run-image = "heroku/heroku:20-cnb"
+build-image = "docker.io/heroku/heroku:20-cnb-build"
+run-image = "docker.io/heroku/heroku:20-cnb"
+run-image-mirrors = ["public.ecr.aws/heroku/heroku:20-cnb"]
+
+[build]
+image = "docker.io/heroku/heroku:20-cnb-build"
+
+[run]
+[[run.images]]
+image = "docker.io/heroku/heroku:20-cnb"
+mirrors = ["public.ecr.aws/heroku/heroku:20-cnb"]
 
 [lifecycle]
 version = "0.20.0"

--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -2,8 +2,17 @@ description = "Ubuntu 22.04 AMD64 base image with buildpacks for Go, Java, Node.
 
 [stack]
 id = "heroku-22"
-build-image = "heroku/heroku:22-cnb-build"
-run-image = "heroku/heroku:22-cnb"
+build-image = "docker.io/heroku/heroku:22-cnb-build"
+run-image = "docker.io/heroku/heroku:22-cnb"
+run-image-mirrors = ["public.ecr.aws/heroku/heroku:22-cnb"]
+
+[build]
+image = "docker.io/heroku/heroku:22-cnb-build"
+
+[run]
+[[run.images]]
+image = "docker.io/heroku/heroku:22-cnb"
+mirrors = ["public.ecr.aws/heroku/heroku:22-cnb"]
 
 [lifecycle]
 version = "0.20.0"

--- a/builder-24/builder.toml
+++ b/builder-24/builder.toml
@@ -2,11 +2,20 @@ description = "Ubuntu 24.04 AMD64+ARM64 base image with buildpacks for Go, Java,
 
 [stack]
 id = "heroku-24"
-build-image = "heroku/heroku:24-build"
-run-image = "heroku/heroku:24"
+build-image = "docker.io/heroku/heroku:24-build"
+run-image = "docker.io/heroku/heroku:24"
+run-image-mirrors = ["public.ecr.aws/heroku/heroku:24"]
 
 [lifecycle]
 version = "0.20.0"
+
+[build]
+image = "heroku/heroku:24-build"
+
+[run]
+[[run.images]]
+image = "docker.io/heroku/heroku:24"
+mirrors = ["public.ecr.aws/heroku/heroku:24"]
 
 [[buildpacks]]
   id = "heroku/go"

--- a/builder-24/builder.toml
+++ b/builder-24/builder.toml
@@ -10,7 +10,7 @@ run-image-mirrors = ["public.ecr.aws/heroku/heroku:24"]
 version = "0.20.0"
 
 [build]
-image = "heroku/heroku:24-build"
+image = "docker.io/heroku/heroku:24-build"
 
 [run]
 [[run.images]]


### PR DESCRIPTION
This PR updates our build/run image configuration for builders by:

1. Referencing the new `public.ecr.aws/heroku/heroku` tags as mirrors
2. Adding explicit `docker.io` domains to the Docker Hub hosted tags (for explicitness and differentiation from the ECR mirrors)
3. Adding the new-ish builder.toml `build` and `run` keys outlined [here]( https://github.com/buildpacks/spec/pull/363/files#diff-83b8682bde66aedd4caaef8d64467832f54d7bf053c51b51dd77c9620c1beae6R221-R238). With this PR, we support both `stacks` (platform API 0.11 and older) and `build` + `run` keys (platform API 0.12 and newer).

[GUS](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001xkt9VYAQ/view)