### PR TITLE
Move heroku/nodejs group to the end

### DIFF
--- a/builder-20/builder.toml
+++ b/builder-20/builder.toml
@@ -91,18 +91,6 @@ version = "0.20.3"
 
 [[order]]
   [[order.group]]
-    id = "heroku/nodejs"
-    version = "3.2.17"
-  [[order.group]]
-    id = "heroku/procfile"
-    version = "3.1.2"
-    optional = true
-  [[order.group]]
-    id = "heroku/eol-warning"
-    version = "1.0.0"
-
-[[order]]
-  [[order.group]]
     id = "heroku/java"
     version = "6.0.3"
   [[order.group]]
@@ -141,6 +129,19 @@ version = "0.20.3"
   [[order.group]]
     id = "heroku/php"
     version = "0.2.0"
+  [[order.group]]
+    id = "heroku/procfile"
+    version = "3.1.2"
+    optional = true
+  [[order.group]]
+    id = "heroku/eol-warning"
+    version = "1.0.0"
+
+# this group is intentionally at the end, because projects in other languages often have e.g. a package.json
+[[order]]
+  [[order.group]]
+    id = "heroku/nodejs"
+    version = "3.2.17"
   [[order.group]]
     id = "heroku/procfile"
     version = "3.1.2"

--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -101,19 +101,6 @@ version = "0.20.3"
     version = "0.0.1"
     optional = true
   [[order.group]]
-    id = "heroku/nodejs"
-    version = "3.2.17"
-  [[order.group]]
-    id = "heroku/procfile"
-    version = "3.1.2"
-    optional = true
-
-[[order]]
-  [[order.group]]
-    id = "heroku/deb-packages"
-    version = "0.0.1"
-    optional = true
-  [[order.group]]
     id = "heroku/java"
     version = "6.0.3"
   [[order.group]]
@@ -168,6 +155,20 @@ version = "0.20.3"
   [[order.group]]
     id = "heroku/dotnet"
     version = "0.1.4"
+  [[order.group]]
+    id = "heroku/procfile"
+    version = "3.1.2"
+    optional = true
+
+# this group is intentionally at the end, because projects in other languages often have e.g. a package.json
+[[order]]
+  [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.0.1"
+    optional = true
+  [[order.group]]
+    id = "heroku/nodejs"
+    version = "3.2.17"
   [[order.group]]
     id = "heroku/procfile"
     version = "3.1.2"

--- a/builder-24/builder.toml
+++ b/builder-24/builder.toml
@@ -101,19 +101,6 @@ mirrors = ["public.ecr.aws/heroku/heroku:24"]
     version = "0.0.1"
     optional = true
   [[order.group]]
-    id = "heroku/nodejs"
-    version = "3.2.17"
-  [[order.group]]
-    id = "heroku/procfile"
-    version = "3.1.2"
-    optional = true
-
-[[order]]
-  [[order.group]]
-    id = "heroku/deb-packages"
-    version = "0.0.1"
-    optional = true
-  [[order.group]]
     id = "heroku/java"
     version = "6.0.3"
   [[order.group]]
@@ -168,6 +155,20 @@ mirrors = ["public.ecr.aws/heroku/heroku:24"]
   [[order.group]]
     id = "heroku/dotnet"
     version = "0.1.4"
+  [[order.group]]
+    id = "heroku/procfile"
+    version = "3.1.2"
+    optional = true
+
+# this group is intentionally at the end, because projects in other languages often have e.g. a package.json
+[[order]]
+  [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.0.1"
+    optional = true
+  [[order.group]]
+    id = "heroku/nodejs"
+    version = "3.2.17"
   [[order.group]]
     id = "heroku/procfile"
     version = "3.1.2"


### PR DESCRIPTION
Apps written in other languages often have a `package.json`, and the current order causes these to be detected as a Node.js codebase.

N.b. the diff for `heroku-20` is just a bit funky looking, it's really the same as for the two others when you look at it with `git diff --patience`:

```diff
diff --git a/builder-20/builder.toml b/builder-20/builder.toml
index 097d01f..c09b53c 100644
--- a/builder-20/builder.toml
+++ b/builder-20/builder.toml
@@ -89,18 +89,6 @@ version = "0.20.1"
     id = "heroku/eol-warning"
     version = "1.0.0"
 
-[[order]]
-  [[order.group]]
-    id = "heroku/nodejs"
-    version = "3.2.13"
-  [[order.group]]
-    id = "heroku/procfile"
-    version = "3.1.2"
-    optional = true
-  [[order.group]]
-    id = "heroku/eol-warning"
-    version = "1.0.0"
-
 [[order]]
   [[order.group]]
     id = "heroku/java"
@@ -148,3 +136,16 @@ version = "0.20.1"
   [[order.group]]
     id = "heroku/eol-warning"
     version = "1.0.0"
+
+# this group is intentionally at the end, because projects in other languages often have e.g. a package.json
+[[order]]
+  [[order.group]]
+    id = "heroku/nodejs"
+    version = "3.2.13"
+  [[order.group]]
+    id = "heroku/procfile"
+    version = "3.1.2"
+    optional = true
+  [[order.group]]
+    id = "heroku/eol-warning"
+    version = "1.0.0"
```

GUS-W-16712980