### PR TITLE
Add `heroku/deb-packages` to 22/24 builders

### DIFF
--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -18,6 +18,10 @@ mirrors = ["public.ecr.aws/heroku/heroku:22-cnb"]
 version = "0.20.3"
 
 [[buildpacks]]
+  id = "heroku/deb-packages"
+  uri = "docker://docker.io/heroku/buildpack-deb-packages@sha256:e78f94e020067a5b68a885eb89a1000f584f21757e4b5fb7cff6047b57d22544"
+
+[[buildpacks]]
   id = "heroku/dotnet"
   uri = "docker://docker.io/heroku/buildpack-dotnet@sha256:374842621436859ed73a3c75db69f856121436fad2acb20447eb043b46fbdc74"
 
@@ -55,6 +59,10 @@ version = "0.20.3"
 
 [[order]]
   [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.0.1"
+    optional = true
+  [[order.group]]
     id = "heroku/python"
     version = "0.19.0"
   [[order.group]]
@@ -63,6 +71,10 @@ version = "0.20.3"
     optional = true
 
 [[order]]
+  [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.0.1"
+    optional = true
   [[order.group]]
     id = "heroku/nodejs-engine"
     version = "3.2.15"
@@ -85,6 +97,10 @@ version = "0.20.3"
 
 [[order]]
   [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.0.1"
+    optional = true
+  [[order.group]]
     id = "heroku/nodejs"
     version = "3.2.15"
   [[order.group]]
@@ -93,6 +109,10 @@ version = "0.20.3"
     optional = true
 
 [[order]]
+  [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.0.1"
+    optional = true
   [[order.group]]
     id = "heroku/java"
     version = "6.0.3"
@@ -103,6 +123,10 @@ version = "0.20.3"
 
 [[order]]
   [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.0.1"
+    optional = true
+  [[order.group]]
     id = "heroku/scala"
     version = "6.0.3"
   [[order.group]]
@@ -111,6 +135,10 @@ version = "0.20.3"
     optional = true
 
 [[order]]
+  [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.0.1"
+    optional = true
   [[order.group]]
     id = "heroku/go"
     version = "0.4.5"
@@ -121,6 +149,10 @@ version = "0.20.3"
 
 [[order]]
   [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.0.1"
+    optional = true
+  [[order.group]]
     id = "heroku/php"
     version = "0.2.0"
   [[order.group]]
@@ -129,6 +161,10 @@ version = "0.20.3"
     optional = true
 
 [[order]]
+  [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.0.1"
+    optional = true
   [[order.group]]
     id = "heroku/dotnet"
     version = "0.1.4"

--- a/builder-24/builder.toml
+++ b/builder-24/builder.toml
@@ -18,6 +18,10 @@ image = "docker.io/heroku/heroku:24"
 mirrors = ["public.ecr.aws/heroku/heroku:24"]
 
 [[buildpacks]]
+  id = "heroku/deb-packages"
+  uri = "docker://docker.io/heroku/buildpack-deb-packages@sha256:e78f94e020067a5b68a885eb89a1000f584f21757e4b5fb7cff6047b57d22544"
+
+[[buildpacks]]
   id = "heroku/dotnet"
   uri = "docker://docker.io/heroku/buildpack-dotnet@sha256:374842621436859ed73a3c75db69f856121436fad2acb20447eb043b46fbdc74"
 
@@ -55,6 +59,10 @@ mirrors = ["public.ecr.aws/heroku/heroku:24"]
 
 [[order]]
   [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.0.1"
+    optional = true
+  [[order.group]]
     id = "heroku/python"
     version = "0.19.0"
   [[order.group]]
@@ -63,6 +71,10 @@ mirrors = ["public.ecr.aws/heroku/heroku:24"]
     optional = true
 
 [[order]]
+  [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.0.1"
+    optional = true
   [[order.group]]
     id = "heroku/nodejs-engine"
     version = "3.2.15"
@@ -85,6 +97,10 @@ mirrors = ["public.ecr.aws/heroku/heroku:24"]
 
 [[order]]
   [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.0.1"
+    optional = true
+  [[order.group]]
     id = "heroku/nodejs"
     version = "3.2.15"
   [[order.group]]
@@ -93,6 +109,10 @@ mirrors = ["public.ecr.aws/heroku/heroku:24"]
     optional = true
 
 [[order]]
+  [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.0.1"
+    optional = true
   [[order.group]]
     id = "heroku/java"
     version = "6.0.3"
@@ -103,6 +123,10 @@ mirrors = ["public.ecr.aws/heroku/heroku:24"]
 
 [[order]]
   [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.0.1"
+    optional = true
+  [[order.group]]
     id = "heroku/scala"
     version = "6.0.3"
   [[order.group]]
@@ -111,6 +135,10 @@ mirrors = ["public.ecr.aws/heroku/heroku:24"]
     optional = true
 
 [[order]]
+  [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.0.1"
+    optional = true
   [[order.group]]
     id = "heroku/go"
     version = "0.4.5"
@@ -121,6 +149,10 @@ mirrors = ["public.ecr.aws/heroku/heroku:24"]
 
 [[order]]
   [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.0.1"
+    optional = true
+  [[order.group]]
     id = "heroku/php"
     version = "0.2.0"
   [[order.group]]
@@ -129,6 +161,10 @@ mirrors = ["public.ecr.aws/heroku/heroku:24"]
     optional = true
 
 [[order]]
+  [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.0.1"
+    optional = true
   [[order.group]]
     id = "heroku/dotnet"
     version = "0.1.4"


### PR DESCRIPTION
Registers the [heroku/deb-packages buildpack](https://github.com/heroku/buildpacks-deb-packages) in the following builders, prepending it to each buildpack group as an optional buildpack that runs at the start for:
- `heroku/builder:24`
- `heroku/builder:22`

> [!note]
> This will not be added to `heroku/builder:20` as that builder is deprecated.

GUS-W-17066441.