### PR TITLE
Reduce scopes granted to `GITHUB_TOKEN` in GitHub Actions workflows

### DIFF
--- a/.github/workflows/update-lifecycle.yml
+++ b/.github/workflows/update-lifecycle.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 8 * * MON'
   workflow_dispatch:
 
+# Disable all GITHUB_TOKEN permissions, since the GitHub App token is used instead.
+permissions: {}
+
 jobs:
   update-lifecycle:
     name: Update lifecycle


### PR DESCRIPTION
As part of security-hardening our GHA workflows, this reduces the permissions granted to the automatically set `GITHUB_TOKEN` env var in GitHub Actions workflows to no more than what is required by that workflow.

See:
https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication

GUS-W-18053749.