### PR TITLE
Stop setting `DYNO` when running the test apps in CI

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -101,12 +101,10 @@ jobs:
       - name: Build getting started guide image
         run: pack build getting-started --force-color --builder ${{ matrix.builder }} --trust-builder --pull-policy never
       - name: Start getting started guide image
-        # The `DYNO` env var is set to more accurately reflect the Heroku environment, since some of the getting
-        # started guides use the presence of `DYNO` to determine whether to enable production mode or not.
-        run: docker run --name getting-started --detach -p 8080:8080 --env PORT=8080 --env DYNO=web.1 getting-started
+        run: docker run --name getting-started --detach -p 8080:8080 --env PORT=8080 getting-started
       - name: Test getting started web server response
         run: |
-          if curl -sSf --retry 10 --retry-delay 1 --retry-all-errors --connect-timeout 3 http://localhost:8080 -o response.txt; then
+          if curl -sSfL --retry 10 --retry-delay 1 --retry-all-errors --connect-timeout 3 http://localhost:8080 -o response.txt; then
             echo "Successful response from server"
           else
             echo "Server did not respond successfully"
@@ -146,10 +144,10 @@ jobs:
       - name: Build example function image
         run: pack build example-function --path salesforce-functions/examples/${{ matrix.language }} --builder salesforce-functions --trust-builder --pull-policy never
       - name: Start example function image
-        run: docker run --name example-function --detach -p 8080:8080 --env PORT=8080 --env DYNO=web.1 example-function
+        run: docker run --name example-function --detach -p 8080:8080 --env PORT=8080 example-function
       - name: Test example function web server response
         run: |
-          if curl -sSf --retry 10 --retry-delay 1 --retry-all-errors --connect-timeout 3 -X POST -H 'x-health-check: true' http://localhost:8080 -o response.txt; then
+          if curl -sSfL --retry 10 --retry-delay 1 --retry-all-errors --connect-timeout 3 -X POST -H 'x-health-check: true' http://localhost:8080 -o response.txt; then
             echo "Successful response from function"
           else
             echo "Function did not respond successfully"


### PR DESCRIPTION
Since this env var was added in #385 primarily for the Python Getting Started Guide, but that guide:
- No longer requires that the env var be set in order to run in production mode, as of:
  https://github.com/heroku/python-getting-started/pull/251
- Now redirects to HTTPS if `DYNO` is set (which is not what we want for these tests, since there is no TLS cert configured), as of:
  https://github.com/heroku/python-getting-started/pull/253

Also, we're about to add Direwolf tests for CNBs/Fir, which will test the guides in a true Heroku-like setting, so it makes more sense for these smoke tests to more accurately test the local `pack build` workflow instead - rather than a hybrid of both.

Lastly, I've added `-L` to the curl usages (which makes it follow redirects), so that any issues with redirects are caught in CI. (Such as the Python Getting Started Guide HTTP 301 redirecting to an HTTPS URL with no cert, when the `DYNO` env var was set.)

GUS-W-18093965.