### PR TITLE
Upgrade the `heroku/builder:20` deprecation warning to an error

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Load Docker images into the Docker daemon
         run: zstd -dc --long=31 images.tar.zst | docker load
       - name: Build getting started guide image
-        run: pack build getting-started --force-color --builder ${{ matrix.builder }} --trust-builder --pull-policy never
+        run: pack build getting-started --force-color --builder ${{ matrix.builder }} --trust-builder --pull-policy never --env ALLOW_EOL_HEROKU_BUILDER_20=1
       - name: Start getting started guide image
         run: docker run --name getting-started --detach -p 8080:8080 --env PORT=8080 getting-started
       - name: Test getting started web server response

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ in each base image, see [this Dev Center article](https://devcenter.heroku.com/a
 
 | Builder Image                     | OS           | Supported Architectures | Default Run Image                   | Lifecycle Version | Status      |
 |-----------------------------------|--------------|-------------------------|-------------------------------------|-------------------|-------------|
-| [heroku/builder:20][builder-tags] | Ubuntu 20.04 | AMD64                   | [heroku/heroku:20-cnb][heroku-tags] | 0.20.8            | Deprecated  |
+| [heroku/builder:20][builder-tags] | Ubuntu 20.04 | AMD64                   | [heroku/heroku:20-cnb][heroku-tags] | 0.20.8            | End-of-life |
 | [heroku/builder:22][builder-tags] | Ubuntu 22.04 | AMD64                   | [heroku/heroku:22-cnb][heroku-tags] | 0.20.8            | Available   |
 | [heroku/builder:24][builder-tags] | Ubuntu 24.04 | AMD64 + ARM64           | [heroku/heroku:24][heroku-tags]     | 0.20.8            | Recommended |
 

--- a/builder-20/builder.toml
+++ b/builder-20/builder.toml
@@ -55,17 +55,20 @@ version = "0.20.8"
 
 [[order]]
   [[order.group]]
+    id = "heroku/eol-warning"
+    version = "2.0.0"
+  [[order.group]]
     id = "heroku/python"
     version = "0.26.1"
   [[order.group]]
     id = "heroku/procfile"
     version = "4.2.1"
     optional = true
-  [[order.group]]
-    id = "heroku/eol-warning"
-    version = "1.0.0"
 
 [[order]]
+  [[order.group]]
+    id = "heroku/eol-warning"
+    version = "2.0.0"
   [[order.group]]
     id = "heroku/nodejs-engine"
     version = "3.6.1"
@@ -85,11 +88,11 @@ version = "0.20.8"
     id = "heroku/procfile"
     version = "4.2.1"
     optional = true
-  [[order.group]]
-    id = "heroku/eol-warning"
-    version = "1.0.0"
 
 [[order]]
+  [[order.group]]
+    id = "heroku/eol-warning"
+    version = "2.0.0"
   [[order.group]]
     id = "heroku/java"
     version = "6.2.1"
@@ -97,11 +100,11 @@ version = "0.20.8"
     id = "heroku/procfile"
     version = "4.2.1"
     optional = true
-  [[order.group]]
-    id = "heroku/eol-warning"
-    version = "1.0.0"
 
 [[order]]
+  [[order.group]]
+    id = "heroku/eol-warning"
+    version = "2.0.0"
   [[order.group]]
     id = "heroku/scala"
     version = "6.2.1"
@@ -109,11 +112,11 @@ version = "0.20.8"
     id = "heroku/procfile"
     version = "4.2.1"
     optional = true
-  [[order.group]]
-    id = "heroku/eol-warning"
-    version = "1.0.0"
 
 [[order]]
+  [[order.group]]
+    id = "heroku/eol-warning"
+    version = "2.0.0"
   [[order.group]]
     id = "heroku/go"
     version = "1.0.0"
@@ -121,11 +124,11 @@ version = "0.20.8"
     id = "heroku/procfile"
     version = "4.2.1"
     optional = true
-  [[order.group]]
-    id = "heroku/eol-warning"
-    version = "1.0.0"
 
 [[order]]
+  [[order.group]]
+    id = "heroku/eol-warning"
+    version = "2.0.0"
   [[order.group]]
     id = "heroku/php"
     version = "1.0.0"
@@ -133,12 +136,12 @@ version = "0.20.8"
     id = "heroku/procfile"
     version = "4.2.1"
     optional = true
-  [[order.group]]
-    id = "heroku/eol-warning"
-    version = "1.0.0"
 
 # this group is intentionally at the end, because projects in other languages often have e.g. a package.json
 [[order]]
+  [[order.group]]
+    id = "heroku/eol-warning"
+    version = "2.0.0"
   [[order.group]]
     id = "heroku/nodejs"
     version = "3.6.1"
@@ -146,6 +149,3 @@ version = "0.20.8"
     id = "heroku/procfile"
     version = "4.2.1"
     optional = true
-  [[order.group]]
-    id = "heroku/eol-warning"
-    version = "1.0.0"

--- a/builder-20/eol-buildpack/bin/build
+++ b/builder-20/eol-buildpack/bin/build
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+ENV_DIR="${2}/env"
+ENV_VAR_NAME='ALLOW_EOL_HEROKU_BUILDER_20'
+ALLOW_BUILD="$(cat "${ENV_DIR}/${ENV_VAR_NAME}" 2> /dev/null || true)"
+
 ANSI_RED="\033[1;31m"
 ANSI_RESET="\033[0m"
 
@@ -13,9 +17,17 @@ function display_error() {
   echo >&2
 }
 
+if [[ "${ALLOW_BUILD}" == "1" ]]; then
+  MSG_FOOTER="Allowing the build to continue since ${ENV_VAR_NAME} is set."
+  EXIT_CODE=0
+else
+  MSG_FOOTER="To ignore this error, set the env var ${ENV_VAR_NAME} to 1."
+  EXIT_CODE=1
+fi
+
 # Banner generated via https://www.ascii-art-generator.org/ with "big" font
 # and 70 width.
-read -r -d '' EOL_MESSAGE <<'EOF' || true
+read -r -d '' EOL_MESSAGE <<EOF || true
 #######################################################################
  _                    _               ___   ___    ______ ____  _
 | |                  | |             |__ \ / _ \  |  ____/ __ \| |
@@ -24,7 +36,7 @@ read -r -d '' EOL_MESSAGE <<'EOF' || true
 | | | |  __/ | | (_) |   <| |_| |     / /_| |_| | | |___| |__| | |____
 |_| |_|\___|_|  \___/|_|\_\\\__,_|    |____|\___/  |______\____/|______|
 
-This builder image ('heroku/builder:20') is deprecated, since it is
+This builder image ('heroku/builder:20') has been sunset, since it is
 based on the deprecated 'heroku/heroku:20' base image.
 
 Starting April 30th, 2025, this image will no longer receive security
@@ -42,9 +54,12 @@ https://buildpacks.io/docs/tools/pack/cli/pack_config_default-builder/
 
 If you are using a third-party platform to deploy your app, check the
 platform documentation for instructions on changing the builder.
+
+${MSG_FOOTER}
+
 #######################################################################
 EOF
 
 display_error "${EOL_MESSAGE}"
 
-exit 0
+exit ${EXIT_CODE}

--- a/builder-20/eol-buildpack/buildpack.toml
+++ b/builder-20/eol-buildpack/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.10"
 
 [buildpack]
   id = "heroku/eol-warning"
-  version = "1.0.0"
+  version = "2.0.0"
   name = "heroku/builder:20 End-of-Life Warning"
   homepage = "https://github.com/heroku/cnb-builder-images"
 


### PR DESCRIPTION
Heroku-20, Heroku's Ubuntu 20.04 based stack, was previously deprecated in June 2024:
https://devcenter.heroku.com/changelog-items/2895

The `heroku/builder:20` image has been outputting deprecation warnings since July 2024:
https://github.com/heroku/cnb-builder-images/pull/552

Now, in accordance with our stack support policy and the documented EOL timelines, the stack and thus the builder image have reached end-of-life.

As such, the EOL warnings have been upgraded to errors (which can be bypassed by setting an env var), similar to what we did for the legacy builder image sunset in #478.

Users who want to continue to use this builder, will need to set the env var:
`ALLOW_EOL_HEROKU_BUILDER_20=1`

The EOL warning buildpack has been moved first in the group detection order, so that builds fail fast - preventing wasting time and also making the error clearly since it's not surrounded by the rest of the buildpack logs.

GUS-W-14706656.