### PR TITLE
Switch to GitHub Actions public `ubuntu-24.04-arm` runner

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -33,7 +33,7 @@ jobs:
             arch: arm64
           - builder: salesforce-functions
             arch: arm64
-    runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-medium' || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -61,7 +61,7 @@ jobs:
           path: images.tar.zst
 
   test:
-    runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-medium' || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     needs: create
     strategy:
       fail-fast: false
@@ -161,7 +161,7 @@ jobs:
           fi
 
   publish-image:
-    runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-medium' || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     if: success() && github.ref == 'refs/heads/main'
     needs: ["test", "test-functions"]
     strategy:


### PR DESCRIPTION
In January 2025, GitHub Actions announced preview support for public ARM GitHub Actions runners (previously only available when using the custom runners group feature):
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

The public runners were then GAed this month:
https://github.blog/changelog/2025-08-07-arm64-hosted-runners-for-public-repositories-are-now-generally-available/

The Python CNB has been successfully using the public runners since then (in the first few weeks there was an issue with crashes due to the public runners using newer CPU model, but that's since been resolved).

The public runners are faster to boot than the custom runners, since GitHub has a slack pool of them. (When comparing test end to end times, bear in mind that GitHub doesn't include the queue time in the reported job time.)

As such, for any use-case that doesn't need a larger number of CPUs, we should use the public runners instead. (Even for CPU bound workloads, the slower boot time often outweighs the benefit of having more CPUs.)

GUS-W-19324156.