### PR TITLE
Update lifecycle from v0.20.12 to v0.20.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ in each base image, see [this Dev Center article](https://devcenter.heroku.com/a
 
 | Builder Image                     | OS           | Supported Architectures | Default Run Image                   | Lifecycle Version | Status      |
 |-----------------------------------|--------------|-------------------------|-------------------------------------|-------------------|-------------|
-| [heroku/builder:20][builder-tags] | Ubuntu 20.04 | AMD64                   | [heroku/heroku:20-cnb][heroku-tags] | 0.20.12            | End-of-life |
-| [heroku/builder:22][builder-tags] | Ubuntu 22.04 | AMD64                   | [heroku/heroku:22-cnb][heroku-tags] | 0.20.12            | Available   |
-| [heroku/builder:24][builder-tags] | Ubuntu 24.04 | AMD64 + ARM64           | [heroku/heroku:24][heroku-tags]     | 0.20.12            | Recommended |
+| [heroku/builder:20][builder-tags] | Ubuntu 20.04 | AMD64                   | [heroku/heroku:20-cnb][heroku-tags] | 0.20.11            | End-of-life |
+| [heroku/builder:22][builder-tags] | Ubuntu 22.04 | AMD64                   | [heroku/heroku:22-cnb][heroku-tags] | 0.20.13            | Available   |
+| [heroku/builder:24][builder-tags] | Ubuntu 24.04 | AMD64 + ARM64           | [heroku/heroku:24][heroku-tags]     | 0.20.13            | Recommended |
 
 The builder images above include buildpack support for the following languages: Go, Java, Node.js, PHP, Python, Ruby & Scala.
 Additionally, `heroku/builder:22` and `heroku/builder:24` includes buildpack support for .NET applications.

--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -15,7 +15,7 @@ image = "docker.io/heroku/heroku:22-cnb"
 mirrors = ["public.ecr.aws/heroku/heroku:22-cnb"]
 
 [lifecycle]
-version = "0.20.12"
+version = "0.20.13"
 
 [[buildpacks]]
   id = "heroku/deb-packages"

--- a/builder-24/builder.toml
+++ b/builder-24/builder.toml
@@ -7,7 +7,7 @@ run-image = "docker.io/heroku/heroku:24"
 run-image-mirrors = ["public.ecr.aws/heroku/heroku:24"]
 
 [lifecycle]
-version = "0.20.12"
+version = "0.20.13"
 
 [build]
 image = "docker.io/heroku/heroku:24-build"


### PR DESCRIPTION
(I'm opening a manual PR for this, since the GHA workflow doesn't support updating to releases still listed as pre-release)

Release notes:
https://github.com/buildpacks/lifecycle/releases/tag/v0.20.13

Full changelog:
https://github.com/buildpacks/lifecycle/compare/v0.20.12...v0.20.13

Also corrects the lifecycle version listed in README for `heroku/builder:20`, which is no longer updated.

GUS-W-19336168.