### PR TITLE
[builder-22] Remove v4 Node.js CNB references

### DIFF
--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -57,18 +57,6 @@ version = "0.20.13"
   id = "heroku/scala"
   uri = "docker://docker.io/heroku/buildpack-scala@sha256:1b16cfca86d29b083a3627a1b2525ed1baea869d91b9c69c94cc28147435033e"
 
-# NOTE: This is a reference to heroku/nodejs-engine@4.1.4 which is needed temporarily 
-#       until the heroku/ruby CNB can be updated to use heroku/nodejs@5.0.0
-[[buildpacks]]
-  id = "heroku/nodejs-engine"
-  uri = "docker.io/heroku/buildpack-nodejs-engine@sha256:0b0e53c4ff8ae91421a5ec398f0e7184947d130d2691f3009b5295161f9f5fe6"
-  
-# NOTE: This is a reference to heroku/nodejs-yarn@4.1.4 which is needed temporarily 
-#       until the heroku/ruby CNB can be updated to use heroku/nodejs@5.0.0
-[[buildpacks]]
-  id = "heroku/nodejs-yarn"
-  uri = "docker.io/heroku/buildpack-nodejs-yarn@sha256:94a448d8e7d0543767417a7ca2374afbecabbf77c91ba27b82b3be98928c5a17"
-
 [[order]]
   [[order.group]]
     id = "heroku/deb-packages"
@@ -88,12 +76,8 @@ version = "0.20.13"
     version = "0.2.0"
     optional = true
   [[order.group]]
-    id = "heroku/nodejs-engine"
-    version = "4.1.4"
-    optional = true
-  [[order.group]]
-    id = "heroku/nodejs-yarn"
-    version = "4.1.4"
+    id = "heroku/nodejs"
+    version = "5.0.1"
     optional = true
   [[order.group]]
     id = "heroku/jvm"


### PR DESCRIPTION
> [!IMPORTANT]
> Don't merge this until https://github.com/heroku/buildpacks-ruby/pull/452 is merged.

Removes the temporary Node.js CNB references added in https://github.com/heroku/cnb-builder-images/pull/797 once the Ruby CNB migrates to v5 in https://github.com/heroku/buildpacks-ruby/pull/452.

[W-19524974](https://gus.lightning.force.com/a07EE00002LAeqPYAT)