### PR TITLE
Add heroku/deb-packages v1.0.0 to builder-26

### DIFF
--- a/builder-26/builder.toml
+++ b/builder-26/builder.toml
@@ -18,10 +18,9 @@ image = "docker.io/heroku/heroku:26-build"
 image = "docker.io/heroku/heroku:26"
 mirrors = ["public.ecr.aws/heroku/heroku:26"]
 
-# TODO: Re-enable once the .deb packages CNB supports Heroku-26.
-# [[buildpacks]]
-#   id = "heroku/deb-packages"
-#   uri = "docker://docker.io/heroku/buildpack-deb-packages@sha256:TODO"
+[[buildpacks]]
+  id = "heroku/deb-packages"
+  uri = "docker://docker.io/heroku/buildpack-deb-packages@sha256:282783174259d1559e1f2e068d2db46281557c3cc71eba4f76b6b1bf1ae7dd4e"
 
 [[buildpacks]]
   id = "heroku/dotnet"
@@ -62,11 +61,10 @@ mirrors = ["public.ecr.aws/heroku/heroku:26"]
   uri = "docker://docker.io/heroku/buildpack-scala@sha256:a36e49a1bf9f8fa14d0e2fc87793213a840dbd5b8ea183b89b0e39ec91f35980"
 
 [[order]]
-  # TODO: Re-enable once the .deb packages CNB supports Heroku-26.
-  # [[order.group]]
-  #   id = "heroku/deb-packages"
-  #   version = "TODO"
-  #   optional = true
+  [[order.group]]
+    id = "heroku/deb-packages"
+    version = "1.0.0"
+    optional = true
   [[order.group]]
     id = "heroku/python"
     version = "6.4.1"
@@ -98,11 +96,10 @@ mirrors = ["public.ecr.aws/heroku/heroku:26"]
 #     optional = true
 
 [[order]]
-  # TODO: Re-enable once the .deb packages CNB supports Heroku-26.
-  # [[order.group]]
-  #   id = "heroku/deb-packages"
-  #   version = "TODO"
-  #   optional = true
+  [[order.group]]
+    id = "heroku/deb-packages"
+    version = "1.0.0"
+    optional = true
   [[order.group]]
     id = "heroku/java"
     version = "7.0.10"
@@ -112,11 +109,10 @@ mirrors = ["public.ecr.aws/heroku/heroku:26"]
     optional = true
 
 [[order]]
-  # TODO: Re-enable once the .deb packages CNB supports Heroku-26.
-  # [[order.group]]
-  #   id = "heroku/deb-packages"
-  #   version = "TODO"
-  #   optional = true
+  [[order.group]]
+    id = "heroku/deb-packages"
+    version = "1.0.0"
+    optional = true
   [[order.group]]
     id = "heroku/scala"
     version = "7.0.10"
@@ -126,11 +122,10 @@ mirrors = ["public.ecr.aws/heroku/heroku:26"]
     optional = true
 
 [[order]]
-  # TODO: Re-enable once the .deb packages CNB supports Heroku-26.
-  # [[order.group]]
-  #   id = "heroku/deb-packages"
-  #   version = "TODO"
-  #   optional = true
+  [[order.group]]
+    id = "heroku/deb-packages"
+    version = "1.0.0"
+    optional = true
   [[order.group]]
     id = "heroku/go"
     version = "2.2.2"
@@ -154,11 +149,10 @@ mirrors = ["public.ecr.aws/heroku/heroku:26"]
 #     optional = true
 
 [[order]]
-  # TODO: Re-enable once the .deb packages CNB supports Heroku-26.
-  # [[order.group]]
-  #   id = "heroku/deb-packages"
-  #   version = "TODO"
-  #   optional = true
+  [[order.group]]
+    id = "heroku/deb-packages"
+    version = "1.0.0"
+    optional = true
   [[order.group]]
     id = "heroku/dotnet"
     version = "1.0.5"
@@ -169,11 +163,10 @@ mirrors = ["public.ecr.aws/heroku/heroku:26"]
 
 # this group is intentionally at the end, because projects in other languages often have e.g. a package.json
 [[order]]
-  # TODO: Re-enable once the .deb packages CNB supports Heroku-26.
-  # [[order.group]]
-  #   id = "heroku/deb-packages"
-  #   version = "TODO"
-  #   optional = true
+  [[order.group]]
+    id = "heroku/deb-packages"
+    version = "1.0.0"
+    optional = true
   [[order.group]]
     id = "heroku/nodejs"
     version = "5.5.7"


### PR DESCRIPTION
This was missed in #952 where the commented-out TODOs should have been
uncommented now that the .deb packages CNB supports Heroku-26.