### PR TITLE
Deprecate `heroku/builder:22`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ in each base image, see [this Dev Center article](https://devcenter.heroku.com/a
 
 | Builder Image                     | OS           | Supported Architectures | Default Run Image                   | Lifecycle Version | Status      |
 |-----------------------------------|--------------|-------------------------|-------------------------------------|-------------------|-------------|
-| [heroku/builder:22][builder-tags] | Ubuntu 22.04 | AMD64                   | [heroku/heroku:22-cnb][heroku-tags] | 0.21.9           | Available   |
+| [heroku/builder:22][builder-tags] | Ubuntu 22.04 | AMD64                   | [heroku/heroku:22-cnb][heroku-tags] | 0.21.9           | Deprecated  |
 | [heroku/builder:24][builder-tags] | Ubuntu 24.04 | AMD64 + ARM64           | [heroku/heroku:24][heroku-tags]     | 0.21.9           | Available   |
 | [heroku/builder:26][builder-tags] | Ubuntu 26.04 | AMD64 + ARM64           | [heroku/heroku:26][heroku-tags]     | 0.21.9           | Recommended |
 

--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -1,4 +1,4 @@
-description = "Ubuntu 22.04 AMD64 base image with buildpacks for .NET, Go, Java, Node.js, PHP, Python, Ruby & Scala."
+description = "[DEPRECATED] Ubuntu 22.04 AMD64 base image with buildpacks for .NET, Go, Java, Node.js, PHP, Python, Ruby & Scala."
 
 [stack]
 id = "heroku-22"
@@ -16,6 +16,10 @@ mirrors = ["public.ecr.aws/heroku/heroku:22-cnb"]
 
 [lifecycle]
 version = "0.21.9"
+
+[[buildpacks]]
+  id = "heroku/eol-warning"
+  uri = "./eol-buildpack/"
 
 [[buildpacks]]
   id = "heroku/deb-packages"
@@ -69,6 +73,9 @@ version = "0.21.9"
     id = "heroku/procfile"
     version = "4.2.2"
     optional = true
+  [[order.group]]
+    id = "heroku/eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
@@ -90,6 +97,9 @@ version = "0.21.9"
     id = "heroku/procfile"
     version = "4.2.2"
     optional = true
+  [[order.group]]
+    id = "heroku/eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
@@ -103,6 +113,9 @@ version = "0.21.9"
     id = "heroku/procfile"
     version = "4.2.2"
     optional = true
+  [[order.group]]
+    id = "heroku/eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
@@ -116,6 +129,9 @@ version = "0.21.9"
     id = "heroku/procfile"
     version = "4.2.2"
     optional = true
+  [[order.group]]
+    id = "heroku/eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
@@ -129,6 +145,9 @@ version = "0.21.9"
     id = "heroku/procfile"
     version = "4.2.2"
     optional = true
+  [[order.group]]
+    id = "heroku/eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
@@ -142,6 +161,9 @@ version = "0.21.9"
     id = "heroku/procfile"
     version = "4.2.2"
     optional = true
+  [[order.group]]
+    id = "heroku/eol-warning"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]
@@ -155,6 +177,9 @@ version = "0.21.9"
     id = "heroku/procfile"
     version = "4.2.2"
     optional = true
+  [[order.group]]
+    id = "heroku/eol-warning"
+    version = "1.0.0"
 
 # this group is intentionally at the end, because projects in other languages often have e.g. a package.json
 [[order]]
@@ -169,3 +194,6 @@ version = "0.21.9"
     id = "heroku/procfile"
     version = "4.2.2"
     optional = true
+  [[order.group]]
+    id = "heroku/eol-warning"
+    version = "1.0.0"

--- a/builder-22/eol-buildpack/bin/build
+++ b/builder-22/eol-buildpack/bin/build
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ANSI_RED="\033[1;31m"
+ANSI_RESET="\033[0m"
+
+function display_error() {
+  echo >&2
+  while IFS= read -r line; do
+    echo -e "${ANSI_RED}${line}${ANSI_RESET}" >&2
+  done <<< "${1}"
+  echo >&2
+}
+
+# Banner generated via https://www.ascii-art-generator.org/ with "big" font
+# and 70 width.
+read -r -d '' EOL_MESSAGE <<'EOF' || true
+#######################################################################
+ _                    _               ___  ___    ______ ____  _
+| |                  | |             |__ \|__ \  |  ____/ __ \| |
+| |__   ___ _ __ ___ | | ___   _ ______ ) |  ) | | |__ | |  | | |
+| '_ \ / _ \ '__/ _ \| |/ / | | |______/ /  / /  |  __|| |  | | |
+| | | |  __/ | | (_) |   <| |_| |     / /_ / /_  | |___| |__| | |____
+|_| |_|\___|_|  \___/|_|\_\\__,_|    |____|____| |______\____/|______|
+
+This builder image ('heroku/builder:22') is deprecated, since it is
+based on the deprecated 'heroku/heroku:22' base image.
+
+Starting April 30th, 2027, this image will no longer receive security
+updates. Shortly after, this builder will be disabled and made
+unavailable.
+
+To continue receiving security updates and avoid interruption, upgrade
+to one of our newer builders, such as 'heroku/builder:24' or
+'heroku/builder:26':
+https://github.com/heroku/cnb-builder-images#available-images
+
+If you are using the Pack CLI, you will need to adjust your '--builder'
+CLI argument or change the default builder configuration:
+https://buildpacks.io/docs/tools/pack/cli/pack_config_default-builder/
+
+If you are using a third-party platform to deploy your app, check the
+platform documentation for instructions on changing the builder.
+#######################################################################
+EOF
+
+display_error "${EOL_MESSAGE}"
+
+exit 0

--- a/builder-22/eol-buildpack/bin/detect
+++ b/builder-22/eol-buildpack/bin/detect
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exit 0

--- a/builder-22/eol-buildpack/buildpack.toml
+++ b/builder-22/eol-buildpack/buildpack.toml
@@ -1,0 +1,10 @@
+api = "0.10"
+
+[buildpack]
+  id = "heroku/eol-warning"
+  version = "1.0.0"
+  name = "heroku/builder:22 End-of-Life Warning"
+  homepage = "https://github.com/heroku/cnb-builder-images"
+
+[[buildpack.licenses]]
+  type = "BSD-3-Clause"


### PR DESCRIPTION
Per:
https://devcenter.heroku.com/changelog-items/3705

The EOL warning buildpack is the same as that used for Heroku-20 (see #552).

GUS-W-20911357.
GUS-W-20911667.