### PR TITLE
Auto-approve buildpack update PRs

### DIFF
--- a/.github/workflows/auto-approve-buildpack-updates.yml
+++ b/.github/workflows/auto-approve-buildpack-updates.yml
@@ -21,6 +21,8 @@ jobs:
     # rejects API calls from GitHub-hosted runners.
     runs-on: pub-hk-ubuntu-24.04-ip
     steps:
+      # Approves as `github-actions[bot]` rather than the Linguist user,
+      # since a user can't approve their own PR.
       - name: Approve PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-approve-buildpack-updates.yml
+++ b/.github/workflows/auto-approve-buildpack-updates.yml
@@ -1,0 +1,28 @@
+name: Auto-approve buildpack update PRs
+
+# Uses `pull_request` (not `pull_request_target`), so fork-source PRs run with
+# secrets stripped and a read-only `GITHUB_TOKEN`. `synchronize` is omitted,
+# so approval only fires on the initial PR open.
+on:
+  pull_request:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-approve:
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login == 'heroku-linguist[bot]' &&
+      startsWith(github.event.pull_request.head.ref, 'update/heroku/buildpacks-')
+    # IP-allowlisted runner used because the heroku org's IP allow list
+    # rejects API calls from GitHub-hosted runners.
+    runs-on: pub-hk-ubuntu-24.04-ip
+    steps:
+      - name: Approve PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr review --approve "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/auto-approve-buildpack-updates.yml
+++ b/.github/workflows/auto-approve-buildpack-updates.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     types:
       - opened
+    # Skip queueing the workflow at all for PRs that don't touch
+    # `builder-*/builder.toml`. The `if:` gate below would also reject
+    # them, but a `paths:` filter prevents the run from being created.
+    paths:
+      - 'builder-*/builder.toml'
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
Approves PRs opened by `heroku-linguist[bot]` from `update/heroku/buildpacks-*` branches using the workflow's `GITHUB_TOKEN`, so the auto-merge already enabled by the buildpack release workflow can fire without a human approval step. Branch protection on `main` continues to enforce the security boundary.

Triple-gated: same-repo (rejects fork PRs), bot author, branch-name prefix. `synchronize` is omitted so approval only fires on initial PR open.

**Requires** "Allow GitHub Actions to create and approve pull requests" to be enabled in [repo settings](https://github.com/heroku/cnb-builder-images/settings/actions) before this is effective.

GUS-W-22597481.