### PR TITLE
Post Honeycomb release marker on builder image publish

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -217,3 +217,64 @@ jobs:
           set -x
           docker manifest create "${{ matrix.tag_uri }}" ${{ matrix.manifest_uris }}
           docker manifest push "${{ matrix.tag_uri }}"
+
+  post-honeycomb-marker:
+    name: Post Honeycomb release marker
+    needs: [publish-image, publish-manifest]
+    # Gate to genuine releases only: a push to main, never the nightly `schedule`
+    # rebuild or a `workflow_dispatch`, both of which republish unchanged images.
+    # The buildpack-update check below narrows it further.
+    if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        # Only the tip commit's author + subject are needed to confirm + label the release.
+        with:
+          fetch-depth: 1
+
+      - name: Post Honeycomb release marker
+        # No-op if the secret isn't configured (e.g. before it's added to the repo),
+        # rather than failing an otherwise-successful release. Secrets can't be used
+        # in an `if:`, so the key is mirrored to env and tested there — GitHub masks
+        # registered secrets in logs regardless, so the mirror is safe.
+        if: env.HONEYCOMB_API_KEY
+        env:
+          HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
+          HONEYCOMB_DATASET: builds
+          COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+        run: |
+          msg=$(git log -1 --format=%s)
+          author=$(git log -1 --format=%an)
+
+          # Builder releases reach main as a Linguist buildpack-update merge, authored by
+          # heroku-linguist[bot] and titled "Update heroku/buildpacks-<lang> to vX.Y.Z" by
+          # the release automation. Require both: the bot author excludes hand-pushed
+          # commits, and the subject excludes the bot's own lifecycle bumps ("Update
+          # lifecycle from ..."). Anything else reaches main too but isn't a release —
+          # skip it without failing.
+          if [[ "$author" != "heroku-linguist[bot]" || "$msg" != Update\ heroku/buildpacks-* ]]; then
+            echo "Not a buildpack-update release (author=${author}, subject=${msg}) — skipping marker."
+            exit 0
+          fi
+
+          api="https://api.honeycomb.io/1/markers/${HONEYCOMB_DATASET}"
+          body=$(jq -n --arg msg "$msg" --arg url "$COMMIT_URL" '{message: $msg, type: "builder-release", url: $url}')
+          auth=(-H "X-Honeycomb-Team: ${HONEYCOMB_API_KEY}" -H "Content-Type: application/json")
+
+          # One marker per builder release; dedup on the commit URL (stable identity for
+          # this release) so a re-run of the workflow updates the existing marker rather
+          # than stacking a duplicate. Every path below warns on failure and never exits
+          # non-zero — a Honeycomb outage must not fail an already-successful release.
+          existing=$(curl -sS --retry 3 --retry-all-errors --max-time 30 "${auth[@]}" "${api}" \
+            | jq -r --arg url "$COMMIT_URL" 'map(select(.url == $url)) | first | .id // empty' 2>/dev/null) || existing=""
+
+          if [[ -n "$existing" ]]; then
+            curl -sS --retry 3 --retry-all-errors --max-time 30 -X PUT "${api}/${existing}" "${auth[@]}" -d "${body}" \
+              >/dev/null && echo "Updated existing release marker (${existing})" \
+              || echo "::warning::Failed to update Honeycomb release marker (release succeeded regardless)"
+          else
+            curl -sS --retry 3 --retry-all-errors --max-time 30 -X POST "${api}" "${auth[@]}" -d "${body}" \
+              >/dev/null && echo "Created release marker for ${msg}" \
+              || echo "::warning::Failed to create Honeycomb release marker (release succeeded regardless)"
+          fi

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -259,22 +259,24 @@ jobs:
           fi
 
           api="https://api.honeycomb.io/1/markers/${HONEYCOMB_DATASET}"
-          body=$(jq -n --arg msg "$msg" --arg url "$COMMIT_URL" '{message: $msg, type: "builder-release", url: $url}')
-          auth=(-H "X-Honeycomb-Team: ${HONEYCOMB_API_KEY}" -H "Content-Type: application/json")
+          curl=(curl -sS --fail --connect-timeout 10 --retry 3 --retry-all-errors --max-time 30
+            -H "X-Honeycomb-Team: ${HONEYCOMB_API_KEY}" -H "Content-Type: application/json")
 
           # One marker per builder release; dedup on the commit URL (stable identity for
-          # this release) so a re-run of the workflow updates the existing marker rather
-          # than stacking a duplicate. Every path below warns on failure and never exits
-          # non-zero — a Honeycomb outage must not fail an already-successful release.
-          existing=$(curl -sS --retry 3 --retry-all-errors --max-time 30 "${auth[@]}" "${api}" \
-            | jq -r --arg url "$COMMIT_URL" 'map(select(.url == $url)) | first | .id // empty' 2>/dev/null) || existing=""
+          # this release). If a marker already exists (e.g. a re-run of the workflow), skip
+          # — the marker is unchanged, so there's nothing to update. Every call warns on
+          # failure and never exits non-zero: a Honeycomb outage must not fail an
+          # already-successful release.
+          existing=$("${curl[@]}" "${api}" \
+            | jq -r --arg url "$COMMIT_URL" 'map(select(.url == $url)) | first | .id // empty') \
+            || { echo "::warning::Failed to query Honeycomb markers (release succeeded regardless)"; exit 0; }
 
           if [[ -n "$existing" ]]; then
-            curl -sS --retry 3 --retry-all-errors --max-time 30 -X PUT "${api}/${existing}" "${auth[@]}" -d "${body}" \
-              >/dev/null && echo "Updated existing release marker (${existing})" \
-              || echo "::warning::Failed to update Honeycomb release marker (release succeeded regardless)"
-          else
-            curl -sS --retry 3 --retry-all-errors --max-time 30 -X POST "${api}" "${auth[@]}" -d "${body}" \
-              >/dev/null && echo "Created release marker for ${msg}" \
-              || echo "::warning::Failed to create Honeycomb release marker (release succeeded regardless)"
+            echo "Release marker already exists (${existing}) — skipping."
+            exit 0
           fi
+
+          body=$(jq -n --arg msg "$msg" --arg url "$COMMIT_URL" '{message: $msg, type: "builder-release", url: $url}')
+          "${curl[@]}" -X POST "${api}" -d "${body}" >/dev/null \
+            && echo "Created release marker for ${msg}" \
+            || echo "::warning::Failed to create Honeycomb release marker (release succeeded regardless)"

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -220,7 +220,7 @@ jobs:
 
   post-honeycomb-marker:
     name: Post Honeycomb release marker
-    needs: [publish-image, publish-manifest]
+    needs: publish-manifest
     # Every push to main rebuilds and republishes the builder, so each one is a genuine
     # release worth tracking. Excludes the nightly `schedule` rebuild and `workflow_dispatch`,
     # both of which republish unchanged images.
@@ -229,37 +229,39 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        # Only the tip commit's subject is needed to label the release.
+        # Only the tip commit's subject and timestamp are needed to label the release.
         with:
           fetch-depth: 1
 
       - name: Post Honeycomb release marker
         env:
           HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
-          HONEYCOMB_DATASET: builds
+          HONEYCOMB_DATASET: heroku-builds-production
           COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
         run: |
           msg=$(git log -1 --format=%s)
+          # Anchor the marker to the release commit time, not "now": this job may run delayed
+          # after a re-trigger, and the commit timestamp is stable across re-runs.
+          start_time=$(git log -1 --format=%ct)
 
           api="https://api.honeycomb.io/1/markers/${HONEYCOMB_DATASET}"
           curl=(curl -sS --fail --connect-timeout 10 --retry 3 --retry-all-errors --max-time 30
             -H "X-Honeycomb-Team: ${HONEYCOMB_API_KEY}" -H "Content-Type: application/json")
 
-          # One marker per builder release; dedup on the commit URL (stable identity for
-          # this release). If a marker already exists (e.g. a re-run of the workflow), skip
-          # — the marker is unchanged, so there's nothing to update. Every call warns on
-          # failure and never exits non-zero: a Honeycomb outage must not fail an
-          # already-successful release.
+          # One marker per builder release; dedup on the commit URL (stable identity for this
+          # release). If a marker already exists (e.g. a re-run of the workflow), skip — the
+          # marker is unchanged, so there's nothing to update. This job is the last in the
+          # workflow and runs after the release has already published, so letting it fail red
+          # on a Honeycomb error surfaces the problem (retry/bug) without blocking the release.
           existing=$("${curl[@]}" "${api}" \
-            | jq -r --arg url "$COMMIT_URL" 'map(select(.url == $url)) | first | .id // empty') \
-            || { echo "::warning::Failed to query Honeycomb markers (release succeeded regardless)"; exit 0; }
+            | jq -r --arg url "$COMMIT_URL" 'map(select(.url == $url)) | first | .id // empty')
 
           if [[ -n "$existing" ]]; then
             echo "Release marker already exists (${existing}) — skipping."
             exit 0
           fi
 
-          body=$(jq -n --arg msg "$msg" --arg url "$COMMIT_URL" '{message: $msg, type: "builder-release", url: $url}')
-          "${curl[@]}" -X POST "${api}" -d "${body}" >/dev/null \
-            && echo "Created release marker for ${msg}" \
-            || echo "::warning::Failed to create Honeycomb release marker (release succeeded regardless)"
+          body=$(jq -n --arg msg "$msg" --arg url "$COMMIT_URL" --argjson start "$start_time" \
+            '{message: $msg, type: "deploy", url: $url, start_time: $start}')
+          "${curl[@]}" -X POST "${api}" -d "${body}"
+          echo "Created release marker for ${msg}"

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -221,42 +221,25 @@ jobs:
   post-honeycomb-marker:
     name: Post Honeycomb release marker
     needs: [publish-image, publish-manifest]
-    # Gate to genuine releases only: a push to main, never the nightly `schedule`
-    # rebuild or a `workflow_dispatch`, both of which republish unchanged images.
-    # The buildpack-update check below narrows it further.
+    # Every push to main rebuilds and republishes the builder, so each one is a genuine
+    # release worth tracking. Excludes the nightly `schedule` rebuild and `workflow_dispatch`,
+    # both of which republish unchanged images.
     if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        # Only the tip commit's author + subject are needed to confirm + label the release.
+        # Only the tip commit's subject is needed to label the release.
         with:
           fetch-depth: 1
 
       - name: Post Honeycomb release marker
-        # No-op if the secret isn't configured (e.g. before it's added to the repo),
-        # rather than failing an otherwise-successful release. Secrets can't be used
-        # in an `if:`, so the key is mirrored to env and tested there — GitHub masks
-        # registered secrets in logs regardless, so the mirror is safe.
-        if: env.HONEYCOMB_API_KEY
         env:
           HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
           HONEYCOMB_DATASET: builds
           COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
         run: |
           msg=$(git log -1 --format=%s)
-          author=$(git log -1 --format=%an)
-
-          # Builder releases reach main as a Linguist buildpack-update merge, authored by
-          # heroku-linguist[bot] and titled "Update heroku/buildpacks-<lang> to vX.Y.Z" by
-          # the release automation. Require both: the bot author excludes hand-pushed
-          # commits, and the subject excludes the bot's own lifecycle bumps ("Update
-          # lifecycle from ..."). Anything else reaches main too but isn't a release —
-          # skip it without failing.
-          if [[ "$author" != "heroku-linguist[bot]" || "$msg" != Update\ heroku/buildpacks-* ]]; then
-            echo "Not a buildpack-update release (author=${author}, subject=${msg}) — skipping marker."
-            exit 0
-          fi
 
           api="https://api.honeycomb.io/1/markers/${HONEYCOMB_DATASET}"
           curl=(curl -sS --fail --connect-timeout 10 --retry 3 --retry-all-errors --max-time 30


### PR DESCRIPTION
Posts a release marker to the Honeycomb `heroku-builds-production` dataset when the builder images are published.

## What

A new `post-honeycomb-marker` job (`needs: publish-manifest`) that posts a [marker](https://docs.honeycomb.io/configure/environments/manage-markers/) to the Honeycomb `heroku-builds-production` dataset on a successful builder release, via the [create-a-marker API](https://docs.honeycomb.io/api/markers/create-a-marker/).

## Behavior

- **Every release:** the job is gated on `success() && github.event_name == 'push' && github.ref == 'refs/heads/main'`. Every push to `main` rebuilds and republishes the builder (picking up new base images, buildpack updates, detection-order changes, etc.), so each one is a genuine release worth tracking. Excludes the nightly `schedule` rebuild and `workflow_dispatch`, both of which republish unchanged images.
- **Idempotent:** dedups on the commit URL, so a workflow re-run finds the existing marker and skips rather than stacking a duplicate.
- **Anchored to the release:** `start_time` is set from the release commit timestamp, so a delayed or re-triggered run still anchors the marker to the release rather than to job-execution time.
- **Fails loud:** this is the final job and runs after the release has already published, so a Honeycomb API error fails the job red (surfacing a retry/bug) without affecting the release.

## Follow-up

Requires the `HONEYCOMB_API_KEY` repo secret (env API key with the create-markers scope) to be added before markers will post.

W-22860436
